### PR TITLE
Add pagination + use serialization class for ticket timeline view

### DIFF
--- a/Server/dggcrm/tickets/serializers.py
+++ b/Server/dggcrm/tickets/serializers.py
@@ -52,9 +52,10 @@ class TicketCommentSerializer(serializers.ModelSerializer):
         read_only_fields = ["author", "created_at", "modified_at"]
 
 
-class TicketTimelineEventSerializer(serializers.Serializer):
+class TicketTimelineSerializer(serializers.Serializer):
     type = serializers.CharField()
     created_at = serializers.DateTimeField()
-    actor = serializers.CharField()
-    actor_id = serializers.IntegerField()
-    message = serializers.CharField()
+    actor_display = serializers.CharField(allow_null=True)
+    actor_id = serializers.IntegerField(allow_null=True)
+    message = serializers.CharField(allow_null=True, required=False)
+    changes = serializers.JSONField(allow_null=True, required=False)


### PR DESCRIPTION
Realized we should probably add pagination for the ticket timeline

```
GET /api/tickets/1/timeline/

HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "type": "audit",
            "created_at": "2026-01-13T05:46:36.854333Z",
            "actor_display": null,
            "actor_id": null,
            "message": null,
            "changes": {
                "ticket_status": [
                    "OPEN",
                    "BLOCKED"
                ]
            }
        },
        {
            "type": "comment",
            "created_at": "2025-12-23T15:02:19.176485Z",
            "actor_display": null,
            "actor_id": null,
            "message": "Before clearly scene especially stage night difficult treatment where send message course wrong nor.",
            "changes": null
        }
    ]
}

```

We still have the ?show query param [both, comment, audit]