### PR TITLE
Implement Oauth mocking for APIs and UIs

### DIFF
--- a/Application/app/auth/callback.tsx
+++ b/Application/app/auth/callback.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AuthCallback() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/auth/user/`, {
+      credentials: "include", // cookies
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Authentication failed");
+        return res.json();
+      })
+      .then((user) => {
+        console.log("Logged in as:", user);
+        router.replace("/"); // redirect to dashboard
+      })
+      .catch(() => {
+        setError("Login failed. Please try again.");
+      });
+  }, [router]);
+
+  if (error) return <p style={{ color: "red" }}>{error}</p>;
+  return <p>Signing you in…</p>;
+}

--- a/Application/app/components/Navbar/Navbar.tsx
+++ b/Application/app/components/Navbar/Navbar.tsx
@@ -3,38 +3,35 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
   IconHome,
-  IconInfoCircle,
   IconTicket,
+  IconUser,
   IconUsers,
   IconCalendarEvent,
-  IconBuilding,
-  IconUser,
+  IconEyeFilled,
   IconLogout,
-  IconSwitchHorizontal,
-  IconEyeFilled
+  IconSwitchHorizontal
 } from '@tabler/icons-react';
 import { Code, Group, Switch } from '@mantine/core';
 import classes from './Navbar.module.css';
 import { useEffect, useState } from 'react';
-
+import { handleLogout } from '@/app/utils/oauth';
 
 const notAdminData = [
   { link: '/home', label: 'Home', icon: IconHome },
   { link: '/tickets', label: 'Tickets', icon: IconTicket },
   { link: '/contacts', label: 'Contacts', icon: IconUsers },
   { link: '/events', label: 'Events', icon: IconCalendarEvent },
-/*  { link: '/profile', label: 'Profile', icon: IconUser }, */
 ];
 
 const adminOnly = [
-  {link: '/admin/management', label: 'Management', icon: IconEyeFilled}
-]
+  { link: '/admin/management', label: 'Management', icon: IconEyeFilled },
+];
 
 export default function NavbarSimple() {
   const pathname = usePathname();
 
-  const [admin, changeMode] = useState(false)
-  const [data, changeData] = useState<typeof notAdminData>(notAdminData)
+  const [admin, changeMode] = useState(false);
+  const [data, changeData] = useState<typeof notAdminData>(notAdminData);
 
   useEffect (() => {
     const assignData = () => {
@@ -44,9 +41,10 @@ export default function NavbarSimple() {
         changeData(notAdminData)
       }
     }
-    assignData()
-  }, [admin])
+    assignData();
+  }, [admin]);
 
+  const showNavbar = pathname !== '/login';
 
   const links = data.map((item) => (
     <Link
@@ -60,12 +58,13 @@ export default function NavbarSimple() {
     </Link>
   ));
 
+  if (!showNavbar) {
+    return null;
+  }
+
   return (
     <nav className={classes.navbar}>
       <div className={classes.navbarMain}>
-        <Group className={classes.header} justify="space-between">
-          <Code fw={700}>v0.0.0</Code>
-        </Group>
         {links}
       </div>
 
@@ -77,16 +76,38 @@ export default function NavbarSimple() {
           onChange={() => changeMode(!admin)}
           />
         </div>
-        <a href="#" className={classes.link} onClick={(event) => event.preventDefault()}>
+
+        <a
+          href="#"
+          className={classes.link}
+          onClick={(event) => event.preventDefault()}
+        >
           <IconSwitchHorizontal className={classes.linkIcon} stroke={1.5} />
           <span>Change account</span>
         </a>
 
-        <a href="#" className={classes.link} onClick={(event) => event.preventDefault()}>
+        <Link
+          className={classes.link}
+          data-active={"/profile" === pathname || undefined}
+          href={"/profile"}
+          key={"profile"}
+        >
+          <IconUser className={classes.linkIcon} stroke={1.5} />
+          <span>Profile</span>
+        </Link>
+
+        <a
+          href="#"
+          className={classes.link}
+          onClick={handleLogout}
+        >
           <IconLogout className={classes.linkIcon} stroke={1.5} />
           <span>Logout</span>
         </a>
       </div>
+      <Group className={classes.header} justify="space-between">
+        <Code fw={700}>v0.0.0</Code>
+      </Group>
     </nav>
   );
 }

--- a/Application/app/login/page.tsx
+++ b/Application/app/login/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React, { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import {
+  Paper,
+  Stack,
+  Text,
+  Title,
+  TextInput,
+  PasswordInput,
+  Button,
+  LoadingOverlay,
+  Divider,
+  Alert,
+} from "@mantine/core";
+import getCookie from '@/app/utils/cookie';
+import { loginWithProvider } from '@/app/utils/oauth';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const searchParams = useSearchParams();
+  const next = searchParams.get("next") || "/";
+  const socialError = searchParams.get("social_error");
+  const errorEmail = searchParams.get("email");
+
+  const login = async () => {
+    setLoading(true);
+    const res = await fetch("/accounts/login/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie('csrftoken'),
+      },
+      body: JSON.stringify({ email, password }),
+      credentials: "include",
+    });
+    setLoading(false);
+
+    if (res.ok) {
+      window.location.href = next;
+    } else {
+      alert("Login failed");
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#f7f7f7",
+      }}
+    >
+      <Paper shadow="lg" radius="md" p="xl" withBorder style={{ width: 400 }}>
+        <LoadingOverlay visible={loading} blur={2} />
+        <Stack spacing="md">
+          <Title order={2} align="center">Sign in</Title>
+
+          {socialError && (
+            <Alert color="red">
+              {socialError === "no_user" && (
+                <>No account exists for {errorEmail}. Please contact support.</>
+              )}
+              {socialError === "no_email" && (
+                <>Social login did not provide an email. Please try another method.</>
+              )}
+            </Alert>
+          )}
+
+          <Button fullWidth variant="outline" color="gray" onClick={() => loginWithProvider("google", next)}>
+            Sign in with Google
+          </Button>
+          <Button fullWidth variant="outline" color="gray" onClick={() => loginWithProvider("discord", next)}>
+            Sign in with Discord
+          </Button>
+        </Stack>
+      </Paper>
+    </div>
+  );
+}

--- a/Application/app/profile/page.tsx
+++ b/Application/app/profile/page.tsx
@@ -1,3 +1,137 @@
+"use client";
+
+import {
+  Title,
+  Paper,
+  Stack,
+  TextInput,
+  Button,
+  Divider,
+  Text,
+  Group,
+  Badge,
+  LoadingOverlay,
+  Notification,
+} from "@mantine/core";
+import { useEffect, useState } from "react";
+import getCookie from '@/app/utils/cookie'
+import { loginWithProvider } from '@/app/utils/oauth';
+
+type User = {
+  username: string;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  email_addresses?: {
+    email: string;
+    primary: boolean;
+    verified: boolean;
+  }[];
+  socialaccounts?: {
+    provider: string;
+    uid: string;
+  }[];
+};
+
 export default function ProfilePage() {
-  return <h1>Profile Page</h1>;
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+
+  useEffect(() => {
+    fetch("/api/auth/user", { credentials: "include" })
+      .then((res) => res.json())
+      .then((data) => {
+        setUser(data);
+        setFirstName(data.first_name || "");
+        setLastName(data.last_name || "");
+      })
+      .catch(() => setError("Failed to load profile"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const updateProfile = async () => {
+    setError(null);
+    const res = await fetch("/api/auth/user", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": getCookie('csrftoken'),
+      },
+      credentials: "include",
+      body: JSON.stringify({ first_name: firstName, last_name: lastName }),
+    });
+    if (!res.ok) setError("Failed to update profile");
+  };
+
+  return (
+    <Paper p="lg" radius="md" withBorder style={{ maxWidth: 600, margin: "auto" }}>
+      <LoadingOverlay visible={loading} />
+      <Stack spacing="lg">
+        <Title order={2}>Account Settings for {user?.username || "..."}</Title>
+        {error && <Notification color="red">{error}</Notification>}
+
+        {/* Profile */}
+        <Divider label="Profile" />
+        <TextInput
+          label="First name"
+          value={firstName}
+          onChange={(e) => setFirstName(e.currentTarget.value)}
+        />
+        <TextInput
+          label="Last name"
+          value={lastName}
+          onChange={(e) => setLastName(e.currentTarget.value)}
+        />
+        <Button onClick={updateProfile}>Save profile</Button>
+
+        {/* Emails */}
+        <Divider label="Emails" />
+        <Stack spacing="xs">
+          {user?.email_addresses?.map((email) => (
+            <Group key={email.email} position="apart">
+              <Text>
+                {email.email}{" "}
+                {email.primary && <Badge color="green" component="span">Primary</Badge>}{" "}
+                {!email.verified && <Badge color="yellow" component="span">Unverified</Badge>}
+              </Text>
+            </Group>
+          ))}
+        </Stack>
+
+        {/* OAuth connections */}
+        <Divider label="Connected accounts / OAuth" />
+        <Stack spacing="sm">
+          {user?.social_accounts?.map((acct) => (
+            <Group key={acct.provider} position="apart">
+              <Text>{acct.provider}</Text>
+              <Button
+                size="xs"
+                color="red"
+                variant="outline"
+                onClick={async () => {
+                  const res = await fetch(`/api/auth/social/connections/${acct.provider}/`, {
+                    method: "DELETE",
+                    headers: { "X-CSRFToken": getCookie('csrftoken') },
+                    credentials: "include",
+                  });
+                  if (res.ok) window.location.reload();
+                  else setError("Failed to remove connection");
+                }}
+              >
+                Disconnect
+              </Button>
+            </Group>
+          ))}
+          <Group>
+            <Button onClick={() => loginWithProvider("google")}>Connect Google</Button>
+            <Button onClick={() => loginWithProvider("discord")}>Connect Discord</Button>
+          </Group>
+        </Stack>
+      </Stack>
+    </Paper>
+  );
 }

--- a/Application/app/tickets/[id]/page.tsx
+++ b/Application/app/tickets/[id]/page.tsx
@@ -1,12 +1,66 @@
-import { Ticket } from "@/app/components/ticket-utils"
-import TicketView from "@/app/components/TicketView"
+'use client';
 
-export default async function TicketInfo({params}: {
-  params: Promise<{id: string}>
-}) {
-  const { id } = await params
-  const ticket = await (await fetch(`${process.env.BACKEND_URL}/api/tickets/${id}`)).json() as Ticket
-  return (
-    <TicketView ticket={ticket}/>
-  )
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import TicketView from "@/app/components/TicketView";
+import { type Ticket } from "@/app/components/ticket-utils";
+import { Loader, Center, Text } from "@mantine/core";
+
+export default function TicketInfoPage() {
+  const { id } = useParams<{ id: string }>();
+
+  const [ticket, setTicket] = useState<Ticket | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const fetchTicket = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/api/tickets/${id}`, {
+          credentials: "include",
+        });
+
+        if (res.status === 404) {
+          throw new Error("Ticket does not exist");
+        }
+
+        if (!res.ok) {
+          throw new Error("Failed to load ticket");
+        }
+
+        const data = (await res.json()) as Ticket;
+        setTicket(data);
+      } catch (err) {
+        console.error(err);
+        setError(`${err}`);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTicket();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <Center h="100%">
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Center h="100%">
+        <Text c="red">{error}</Text>
+      </Center>
+    );
+  }
+
+  if (!ticket) return null;
+
+  return <TicketView ticket={ticket} />;
 }

--- a/Application/app/tickets/page.tsx
+++ b/Application/app/tickets/page.tsx
@@ -48,7 +48,7 @@ export default function TicketPage() {
   const fetchTicketes = async (url?: string) => {
     try {
       setLoading(true);
-      const fetchUrl = url || '/api/tickets/';
+      const fetchUrl = url || '/api/tickets';
       const response = await fetch(fetchUrl);
       console.log('Fetch response:', response);
       const data = await response.json();

--- a/Application/app/utils/cookie.ts
+++ b/Application/app/utils/cookie.ts
@@ -1,0 +1,5 @@
+export default function getCookie(name: string) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(";").shift();
+}

--- a/Application/app/utils/oauth.ts
+++ b/Application/app/utils/oauth.ts
@@ -1,0 +1,44 @@
+import getCookie from '@/app/utils/cookie';
+
+const IS_LOCAL = process.env.NEXT_PUBLIC_USE_MOCK_OAUTH === "true";
+
+export const OAUTH_PROVIDERS = {
+  google: IS_LOCAL ? "mock-google" : "google",
+  discord: IS_LOCAL ? "mock-discord" : "discord",
+};
+
+type Provider = keyof typeof OAUTH_PROVIDERS;
+
+export const loginWithProvider = (provider: Provider, next?: string) => {
+  console.log(process.env.NEXT_PUBLIC_USE_MOCK_OAUTH);
+  const providerId = OAUTH_PROVIDERS[provider];
+
+  const nextParam = next ? `?next=${encodeURIComponent(next)}` : "";
+
+  window.location.href = `/accounts/${providerId}/login/${nextParam}`;
+};
+
+export const handleLogout = async (event: React.MouseEvent) => {
+  event.preventDefault();
+  const csrfToken = getCookie('csrftoken');
+
+  try {
+    const res = await fetch('/accounts/logout/', {
+      method: 'POST',
+      credentials: 'include', // send cookies
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken || '',
+      },
+    });
+
+    if (res.ok) {
+      window.location.href = `/login`;
+    } else {
+      alert('Logout failed');
+    }
+  } catch (error) {
+    console.error('Logout error:', error);
+    alert('Logout failed');
+  }
+};

--- a/Application/next.config.ts
+++ b/Application/next.config.ts
@@ -22,6 +22,10 @@ module.exports = {
   async rewrites() {
     return [
       {
+        source: "/accounts/:path*",
+        destination: `${BACKEND_URL}/accounts/:path*/`,
+      },
+      {
         source: '/api/:path*',
         destination: `${BACKEND_URL}/api/:path*/`,
       },

--- a/Application/proxy.ts
+++ b/Application/proxy.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// Redirect if not loggedin
+export function proxy(request: NextRequest) {
+  const sessionid = request.cookies.get("sessionid");
+  const pathname = request.nextUrl.pathname;
+
+  const isLoginPage = pathname === "/login";
+  const isPublic =
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/favicon") ||
+    pathname.startsWith("/accounts") ||
+    pathname.startsWith("/api");
+
+  if (!sessionid && !isLoginPage && !isPublic) {
+    console.log("Redirecting to /login");
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+  if (sessionid && isLoginPage) {
+    const homeUrl = new URL("/home", request.url)
+    return NextResponse.redirect(homeUrl);
+  }
+
+  return NextResponse.next();
+}

--- a/Server/config/urls.py
+++ b/Server/config/urls.py
@@ -18,10 +18,25 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+urlpatterns = []
+
+# TODO: only add these paths in local dev (NEVER PRODUCTION)
+urlpatterns += [
+    path("accounts/", include("dggcrm.authmock.urls")),
+]
+
 urlpatterns = [
+    # allauth (browser OAuth)
+    path("accounts/", include("allauth.urls")),
+
     path("admin/", admin.site.urls),
     # path('', include('dggcrm.api.urls')),
     path('api/', include('dggcrm.contacts.urls')),
     path('api/', include('dggcrm.events.urls')),
     path('api/', include('dggcrm.tickets.urls')),
+    path('api/', include('dggcrm.accounts.urls')),
+
+    # API auth
+    # path("api/auth/", include("dj_rest_auth.urls")),
+    # path("api/auth/registration/", include("dj_rest_auth.registration.urls")),
 ]

--- a/Server/dggcrm/accounts/adapters.py
+++ b/Server/dggcrm/accounts/adapters.py
@@ -1,0 +1,71 @@
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from allauth.account.adapter import DefaultAccountAdapter
+from allauth.core.exceptions import ImmediateHttpResponse
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.shortcuts import redirect
+from django.core.exceptions import PermissionDenied
+
+class SocialLoginForbidden(Exception):
+    """Raised when a social login is not allowed (non-existing user)."""
+    def __init__(self, email=None):
+        self.email = email
+        super().__init__(f"Social login blocked for {email}")
+
+class SocialAccountAdapter(DefaultSocialAccountAdapter):
+    def pre_social_login(self, request, sociallogin):
+        """
+        Only allow social login for users that already exist.
+        Match against ANY verified email on the account.
+        """
+        if sociallogin.is_existing:
+            return
+
+        email = sociallogin.account.extra_data.get("email")
+        if not email:
+            request.session.flush()
+            raise ImmediateHttpResponse(
+                redirect("/login?social_error=no_email")
+            )
+
+        # First check user table's email, then check EmailAddress table
+        User = get_user_model()
+        if User.objects.filter(email=email).exists():
+            user = User.objects.get(email=email)
+        else:
+            try:
+                email_address = EmailAddress.objects.select_related("user").get(
+                    email__iexact=email,
+                    verified=True,
+                )
+                user = email_address.user
+            except EmailAddress.DoesNotExist:
+                # No verified email anywhere in the system
+                request.session.flush()
+                raise ImmediateHttpResponse(
+                    redirect(f"/login?social_error=no_user&email={email}")
+                )
+
+        # Link this social account to the owning user
+        sociallogin.connect(request, user)
+
+    def is_open_for_signup(self, request, sociallogin):
+        # No signups
+        request.session.flush()
+        return False
+
+    def on_authentication_error(self, request, provider_id, error=None, exception=None, extra_context=None):
+        # Always redirect failed logins to /login with params
+        email = getattr(exception, 'email', '')
+        request.session.flush()
+        return ImmediateHttpResponse(redirect(f'/login?social_error=no_user&email={email}'))
+
+
+class NoNewUsersAccountAdapter(DefaultAccountAdapter):
+    def is_open_for_signup(self, request):
+        return False
+
+    def on_authentication_error(self, request, provider_id, error=None, exception=None, extra_context=None):
+        # Always redirect failed logins to /login with params
+        email = getattr(exception, 'email', '')
+        return ImmediateHttpResponse(redirect(f'/login?social_error=no_user&email={email}'))

--- a/Server/dggcrm/accounts/apps.py
+++ b/Server/dggcrm/accounts/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "dggcrm.accounts"
+    verbose_name = "CRM.accounts"

--- a/Server/dggcrm/accounts/serializers.py
+++ b/Server/dggcrm/accounts/serializers.py
@@ -1,0 +1,40 @@
+from django.contrib.auth import get_user_model
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialAccount
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class UserDetailsSerializer(serializers.ModelSerializer):
+    email_addresses = serializers.SerializerMethodField()
+    social_accounts = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ["id", "username", "email", "first_name", "last_name", "email_addresses", "social_accounts"]
+
+    def get_email_addresses(self, user):
+        return list(
+            EmailAddress.objects.filter(user=user).values(
+                "email",
+                "primary",
+                "verified",
+            )
+        )
+
+    def get_social_accounts(self, user):
+        return [
+            {
+                "provider": sa.provider,
+                "uid": sa.uid,
+                "last_login": sa.last_login,
+            }
+            for sa in SocialAccount.objects.filter(user=user)
+        ]
+
+
+class SocialAccountSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SocialAccount
+        fields = ["id", "provider", "uid"]

--- a/Server/dggcrm/accounts/urls.py
+++ b/Server/dggcrm/accounts/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import SocialConnectionDeleteView, CurrentUserView
+
+urlpatterns = [
+    path("auth/social/connections/<str:provider>/", SocialConnectionDeleteView.as_view(), name="social_connection_delete"),
+    path("auth/user/", CurrentUserView.as_view(), name="current-user")
+]

--- a/Server/dggcrm/accounts/views.py
+++ b/Server/dggcrm/accounts/views.py
@@ -1,0 +1,32 @@
+from .serializers import SocialAccountSerializer, UserDetailsSerializer
+from rest_framework import generics, permissions, status
+from allauth.socialaccount.models import SocialAccount
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+
+class SocialConnectionDeleteView(generics.DestroyAPIView):
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = SocialAccountSerializer
+    lookup_field = "provider"
+
+    def get_queryset(self):
+        return SocialAccount.objects.filter(user=self.request.user)
+
+class CurrentUserView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        serializer = UserDetailsSerializer(request.user)
+        return Response(serializer.data)
+
+    def patch(self, request):
+        serializer = UserDetailsSerializer(
+            request.user,
+            data=request.data,
+            partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/Server/dggcrm/authmock/apps.py
+++ b/Server/dggcrm/authmock/apps.py
@@ -1,0 +1,17 @@
+from django.apps import AppConfig
+
+class AuthMockConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "dggcrm.authmock"
+
+    def ready(self):
+        print("AuthMock ready: registering mock providers")
+        from .mock import MockGoogleProvider, MockGoogleOAuth2Adapter, MockDiscordProvider, MockDiscordOAuth2Adapter
+        from allauth.socialaccount import providers
+
+        MockGoogleProvider.oauth2_adapter_class = MockGoogleOAuth2Adapter
+        MockDiscordProvider.oauth2_adapter_class = MockDiscordOAuth2Adapter
+
+        # Register the mock provider with allauth
+        providers.registry.register(MockGoogleProvider)
+        providers.registry.register(MockDiscordProvider)

--- a/Server/dggcrm/authmock/mock.py
+++ b/Server/dggcrm/authmock/mock.py
@@ -1,0 +1,75 @@
+import requests
+from allauth.socialaccount.providers.oauth2.provider import OAuth2Provider
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter, OAuth2LoginView, OAuth2CallbackView
+
+
+class BaseMockOAuth2Adapter(OAuth2Adapter):
+    """
+    Base adapter for mock OAuth2 providers.
+    Subclasses should define `provider_id`, `authorize_url`, `access_token_url`, `profile_url`.
+    """
+
+    def complete_login(self, request, app, token, **kwargs):
+        # Fetch user info from the mock provider
+        resp = requests.get(
+            self.profile_url,
+            headers={"Authorization": f"Bearer {token.token}"},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        extra_data = resp.json()
+        print(f"USER INFO ({self.provider_id})", extra_data, flush=True)
+        return self.get_provider().sociallogin_from_response(request, extra_data)
+
+
+class MockGoogleOAuth2Adapter(BaseMockOAuth2Adapter):
+    provider_id = "mock-google"
+    authorize_url = "http://localhost:9000/mock-google/authorize"
+    access_token_url = "http://mock_oauth:9000/mock-google/token"
+    profile_url = "http://mock_oauth:9000/mock-google/userinfo"
+
+
+class MockDiscordOAuth2Adapter(BaseMockOAuth2Adapter):
+    provider_id = "mock-discord"
+    authorize_url = "http://localhost:9000/mock-discord/authorize"
+    access_token_url = "http://mock_oauth:9000/mock-discord/token"
+    profile_url = "http://mock_oauth:9000/mock-discord/userinfo"
+
+
+# Providers
+class MockGoogleProvider(OAuth2Provider):
+    id = "mock-google"
+    name = "Mock Google"
+    adapter_class = MockGoogleOAuth2Adapter
+
+    def extract_uid(self, data):
+        return data.get("sub")
+
+    def extract_common_fields(self, data):
+        return {
+            "email": data.get("email"),
+            "first_name": data.get("name"),
+        }
+
+
+class MockDiscordProvider(OAuth2Provider):
+    id = "mock-discord"
+    name = "Mock Discord"
+    adapter_class = MockDiscordOAuth2Adapter
+
+    def extract_uid(self, data):
+        return data.get("sub")
+
+    def extract_common_fields(self, data):
+        return {
+            "email": data.get("email"),
+            "first_name": data.get("username"),
+        }
+
+
+# Views
+mock_google_login = OAuth2LoginView.adapter_view(MockGoogleOAuth2Adapter)
+mock_google_callback = OAuth2CallbackView.adapter_view(MockGoogleOAuth2Adapter)
+
+mock_discord_login = OAuth2LoginView.adapter_view(MockDiscordOAuth2Adapter)
+mock_discord_callback = OAuth2CallbackView.adapter_view(MockDiscordOAuth2Adapter)

--- a/Server/dggcrm/authmock/urls.py
+++ b/Server/dggcrm/authmock/urls.py
@@ -1,0 +1,10 @@
+# dggcrm/authmock/urls.py
+from django.urls import path
+from .mock import mock_google_login, mock_google_callback, mock_discord_login, mock_discord_callback
+
+urlpatterns = [
+    path("mock-google/login/", mock_google_login, name="mock-google_login"),
+    path("mock-google/login/callback/", mock_google_callback, name="mock-google_callback"),
+    path("mock-discord/login/", mock_discord_login, name="mock-discord_login"),
+    path("mock-discord/login/callback/", mock_discord_callback, name="mock-discord_callback"),
+]

--- a/Server/fake/create_users.py
+++ b/Server/fake/create_users.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+import os, sys
+import django
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BASE_DIR))
+
+# -------------------------------------------------------------------
+# Django setup
+# -------------------------------------------------------------------
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+django.setup()
+
+from django.contrib.auth import get_user_model
+from allauth.account.models import EmailAddress
+
+User = get_user_model()
+
+# Define your users
+users_data = [
+    {
+        "username": "admin",
+        "email": "admin@example.com",
+        "first_name": "Admin",
+        "last_name": "Istrator",
+    },
+    {
+        "username": "tiny",
+        "email": "tiny@destiny.gg",
+        "first_name": "Tiny",
+        "last_name": "Mann",
+    },
+    {
+        "username": "dummy",
+        "email": "dumb@example.com",
+        "first_name": "Dummy",
+        "last_name": "Person",
+    },
+    {
+        "username": "unverified",
+        "email": "unverified@example.com",
+        "email_verified": False,
+        "first_name": "Unverified",
+        "last_name": "Email",
+    },
+]
+
+created_users = []
+
+for user_data in users_data:
+    email = user_data["email"]
+
+    user, created = User.objects.get_or_create(
+        email=email,
+        defaults={
+            "username": user_data.get("username", ""),
+            "first_name": user_data.get("first_name", ""),
+            "last_name": user_data.get("last_name", ""),
+        },
+    )
+
+    if created:
+        print(f"Created user {email}")
+    else:
+        # Update existing user fields
+        updated = False
+
+        for field in ["first_name", "last_name"]:
+            value = user_data.get(field)
+            if value is not None and getattr(user, field) != value:
+                setattr(user, field, value)
+                updated = True
+
+        # Optionally update password
+        if "password" in user_data:
+            user.set_password(user_data["password"])
+            updated = True
+
+        if updated:
+            print(f"Updated user {email}")
+        else:
+            print(f"User {email} already up-to-date")
+
+    # Mark email as verified
+    email_address, created = EmailAddress.objects.get_or_create(
+        user=user, email=email, primary=True, verified=user_data.get("email_verified", True)
+    )
+    if created:
+        email_address.save()
+
+    user.save()
+
+if created_users:
+    print(f"Successfully created {len(created_users)} users: {created_users}")
+else:
+    print("No users were created.")

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -1,8 +1,13 @@
 faker
-django  
+requests
+oauthlib
+cryptography
+django
 djangorestframework
 django-cors-headers
 django-environ==0.12.0
 django-auditlog==3.4.1
+django-allauth==65.13.1
+djangorestframework-simplejwt
 psycopg[c]==3.3.2
 argparse

--- a/compose/dev/server/mock-oauth/config.json
+++ b/compose/dev/server/mock-oauth/config.json
@@ -1,0 +1,91 @@
+{
+  "interactiveLogin": true,
+  "httpServer": "NettyWrapper",
+  "loginPagePath": "/app/login.html",
+  "tokenCallbacks": [
+    {
+      "issuerId": "mock-google",
+      "tokenExpiry": 3600,
+      "requestMappings": [
+        {
+          "requestParam": "username",
+          "match": "admin",
+          "claims": {
+            "sub": "admin",
+            "email": "admin@example.com",
+            "name": "Admin"
+          }
+        },
+        {
+          "requestParam": "username",
+          "match": "tiny",
+          "claims": {
+            "sub": "tiny",
+            "email": "tiny@destiny.gg",
+            "name": "Tiny"
+          }
+        },
+        {
+          "requestParam": "username",
+          "match": "dummy",
+          "claims": {
+            "sub": "dummy",
+            "email": "dumb@example.com",
+            "name": "Dummy"
+          }
+        },
+        {
+          "requestParam": "username",
+          "match": "unverified",
+          "claims": {
+            "sub": "unverified",
+            "email": "unverified@example.com",
+            "name": "Unverified Email"
+          }
+        }
+      ]
+    },
+    {
+      "issuerId": "mock-discord",
+      "tokenExpiry": 3600,
+      "requestMappings": [
+        {
+          "requestParam": "username",
+          "match": "admin",
+          "claims": {
+            "sub": "admin",
+            "email": "admin@example.com",
+            "name": "Admin"
+          }
+        },
+        {
+          "requestParam": "username",
+          "match": "tiny",
+          "claims": {
+            "sub": "tiny",
+            "email": "tiny@destiny.gg",
+            "name": "Tiny"
+          }
+        },
+        {
+          "requestParam": "username",
+          "match": "dummy",
+          "claims": {
+            "sub": "dummy",
+            "email": "dumb@example.com",
+            "name": "Dummy"
+          }
+        },
+        {
+          "requestParam": "username",
+          "match": "unverified",
+          "claims": {
+            "sub": "unverified",
+            "email": "unverified@example.com",
+            "name": "Unverified Email"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/compose/dev/server/mock-oauth/login.html
+++ b/compose/dev/server/mock-oauth/login.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Mock OAuth Login</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    >
+</head>
+
+<body>
+<div class="container">
+    <div class="row mt-5 justify-content-center">
+        <div class="col-md-5">
+
+            <!-- MUST POST to /oauth/authorize -->
+            <form method="post">
+
+                <h4 class="mb-3">Mock OAuth2 Login</h4>
+                <hr>
+
+                <div class="form-group">
+                    <label for="userSelect">Select user</label>
+                    <select class="form-control" id="userSelect" name="username" required>
+                        <option value="">-- Choose a user --</option>
+                        <option
+                            value="admin"
+                            data-claims='{"email":"admin@example.com","name":"Admin","sub":"admin"}'
+                        >
+                            admin (admin@example.com)
+                        </option>
+                        <option
+                            value="tiny"
+                            data-claims='{"email":"tiny@destiny.gg","name":"Tiny","sub":"tiny"}'
+                        >
+                            tiny (tiny@destiny.gg)
+                        </option>
+                        <option
+                            value="dummy"
+                            data-claims='{"email":"dumb@example.com","name":"Dummy","sub":"dummy"}'
+                        >
+                            dummy (dumb@example.com)
+                        </option>
+                        <option
+                            value="nonexistent"
+                            data-claims='{"email":"nonexistent@example.com","name":"Does Not Exist","sub":"nonexistent"}'
+                        >
+                            nonexistent (nonexistent@example.com)
+                        </option>
+                        <option
+                            value="nonexistent"
+                            data-claims='{"email":"unverified@example.com","name":"Unverified Email","sub":"unverified"}'
+                        >
+                            unverified (unverified@example.com)
+                        </option>
+                    </select>
+                </div>
+
+                <!-- Claims sent to mock-oauth2-server -->
+                <input type="hidden" name="claims" id="claimsInput">
+                <input type="hidden" name="redirect_uri" value="http://localhost:3030/accounts/mock-google/login/callback/">
+                <input type="hidden" name="response_type" value="code">
+                <input type="hidden" name="scope" value="openid email profile">
+                
+                <button type="submit" class="btn btn-primary btn-block">
+                    Sign in
+                </button>
+            </form>
+
+        </div>
+    </div>
+</div>
+
+<script>
+    const userSelect = document.getElementById("userSelect");
+    const claimsInput = document.getElementById("claimsInput");
+
+    userSelect.addEventListener("change", () => {
+        const selected = userSelect.options[userSelect.selectedIndex];
+        claimsInput.value = selected.dataset.claims || "";
+    });
+
+    const select = document.getElementById('userSelect');
+    const hiddenClaims = document.getElementById('claimsInput');
+
+    select.addEventListener('change', function () {
+        const selected = select.options[select.selectedIndex];
+        hiddenClaims.value = selected.dataset.claims || '{}';
+    });
+
+    // initialize first value
+    if(select.options.length > 1) select.dispatchEvent(new Event('change'));
+</script>
+
+</body>
+</html>

--- a/compose/dev/server/start
+++ b/compose/dev/server/start
@@ -37,6 +37,7 @@ if [ "${CREATE_SUPER_USER}" = "1" ] || [ "${CREATE_SUPER_USER}" = "true" ]; then
     if ! python manage.py createsuperuser --noinput --skip-checks; then
         echo "Superuser creation failed (likely already exists). Continuing..."
     fi
+    python fake/create_users.py
 else
     echo "Skipping super user..."
 fi

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -14,6 +14,7 @@ services:
       - /app/.next
     environment:
       - BACKEND_URL=http://server:8080
+      - NEXT_PUBLIC_USE_MOCK_OAUTH=true
     ports:
       - '3030:3030'
 
@@ -47,6 +48,18 @@ services:
       - ./.envs/.dev/.postgres
     ports:
       - "5432:5432"
+
+  mock_oauth:
+    image: ghcr.io/navikt/mock-oauth2-server:3.0.1
+    container_name: mock_oauth
+    volumes:
+      - ./compose/dev/server/mock-oauth/config.json:/app/config.json
+      - ./compose/dev/server/mock-oauth/login.html:/app/login.html:ro
+    ports:
+      - "9000:9000"
+    environment:
+      SERVER_PORT: 9000
+      JSON_CONFIG_PATH: /app/config.json
 
 volumes:
   dggcrm_dev_postgres_data:


### PR DESCRIPTION
So sorry that it's this big

Resolves #50 

With this PR, we can now mock the frontend + backend for oauth for local dev. Disabling oauth locally is not implemented, since a lot of features will needs some sort of authentication. The admin page may still require using credentials (username and password: admin).

1) Adds `django-allauth` dependency
2) Adds API endpoints for production/local dev oauth (redirects,
   callbacks, etc)
3) Adds mock oauth providers (i.e. `dggcrm.authmocks`)
4) Adds `mock-oauth2-server` with mock frotend for local dev

<img width="600" alt="image" src="https://github.com/user-attachments/assets/21a59c58-434e-4e9d-8fc9-7e91d36a1079" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/81bbb9d2-40e5-4858-9e51-55ec86b0bf7b" />

New /profile page
<img width="600" alt="image" src="https://github.com/user-attachments/assets/9d639012-2674-402c-83fd-09cd427e183a" />

In production, all we'd need to do is import the correct providers in the prod `settings.py` file, and add credentials here:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/dfe012ce-fdcb-4eb4-a1c2-82d4ff6449b1" />
