### PR TITLE
Bulk ticket creation API

### DIFF
--- a/Server/dggcrm/tickets/serializers.py
+++ b/Server/dggcrm/tickets/serializers.py
@@ -1,6 +1,10 @@
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
-from .models import Ticket, TicketStatus, TicketComment
+
+from dggcrm.contacts.models import Contact
+from dggcrm.events.models import Event
+
+from .models import Ticket, TicketStatus, TicketComment, TicketType
 
 User = get_user_model()
 
@@ -76,3 +80,57 @@ class TicketTimelineSerializer(serializers.Serializer):
     actor_id = serializers.IntegerField(allow_null=True)
     message = serializers.CharField(allow_null=True, required=False)
     changes = serializers.JSONField(allow_null=True, required=False)
+
+class BulkTicketCreateSerializer(serializers.Serializer):
+    contact_ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        allow_empty=False,
+        write_only=True,
+        help_text="List of contact IDs to create tickets for"
+    )
+    event_id = serializers.IntegerField(
+        required=False, allow_null=True, help_text="Optional event ID"
+    )
+    ticket_type = serializers.ChoiceField(
+        choices=TicketType.choices,
+        required=False
+    )
+    assigned_to_id = serializers.IntegerField(
+        required=False, allow_null=True
+    )
+    title = serializers.CharField(required=False, allow_blank=True)
+    description = serializers.CharField(required=False, allow_blank=True)
+    priority = serializers.ChoiceField(
+        choices=Ticket.Priority.choices,
+        allow_null=True,
+        default=Ticket.Priority.P3,
+    )
+
+    def validate_priority(self, value):
+        return value if value is not None else Ticket.Priority.P3
+
+    def create(self, validated_data):
+        contact_ids = validated_data.pop("contact_ids")
+        event_id = validated_data.pop("event_id", None)
+        assigned_to_id = validated_data.pop("assigned_to_id", None)
+
+        event = Event.objects.filter(id=event_id).first() if event_id else None
+        assigned_to = User.objects.filter(id=assigned_to_id).first() if assigned_to_id else None
+
+        tickets = []
+        for contact_id in contact_ids:
+            contact = Contact.objects.filter(id=contact_id).first()
+            if not contact:
+                continue  # Skip invalid contact IDs
+            ticket = Ticket(
+                contact=contact,
+                event=event,
+                assigned_to=assigned_to,
+                ticket_status=TicketStatus.OPEN if not assigned_to else TicketStatus.TODO,
+                # IMPORTANT INFOMRATION
+                reported_by=self.context['request'].user,
+                **validated_data
+            )
+            tickets.append(ticket)
+
+        return Ticket.objects.bulk_create(tickets)

--- a/Server/dggcrm/tickets/views.py
+++ b/Server/dggcrm/tickets/views.py
@@ -10,7 +10,7 @@ from django.db.models import Count, Q, F
 from django.contrib.contenttypes.models import ContentType
 
 from .models import Ticket, TicketStatus, TicketType, TicketComment
-from .serializers import TicketSerializer, TicketClaimSerializer, TicketCommentSerializer, TicketTimelineSerializer
+from .serializers import TicketSerializer, BulkTicketCreateSerializer, TicketClaimSerializer, TicketCommentSerializer, TicketTimelineSerializer
 
 # TODO: Handle permissions for views in file
 class TicketViewSet(viewsets.ModelViewSet):
@@ -58,6 +58,17 @@ class TicketViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(contact=contact_id)
 
         return queryset
+
+    # TODO: Limit this API to organizer role or above
+    @action(detail=False, methods=["post"], url_path="bulk", serializer_class=BulkTicketCreateSerializer)
+    def bulk_create_tickets(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        tickets = serializer.save()
+        return Response(
+            {"created_count": len(tickets)},
+            status=status.HTTP_201_CREATED
+        )
 
     # TODO: Limit this API to organizer role or above
     @action(detail=False, methods=["get"])


### PR DESCRIPTION
Resolves #63

This is a backend only change. Adds a new bulk ticket creation API `http://localhost:3030/api/tickets/bulk/`:

It takes this as a body:

```
{
    "contact_ids": [1,2,3,4,5],
    "event_id": 2, # Can also be null
    "ticket_type": "UNKNOWN",
    "assigned_to_id": 3,
    "title": "This is generated 2 title",
    "description": "generated\ngenerated\ngenerated\n...",
    "priority": null
}
```

And returns this as a response:

```
{
    "created_count": 5
}
```