### PR TITLE
Update UI with ticket bulk creation modal + other components

### DIFF
--- a/Application/app/components/SearchSelect.tsx
+++ b/Application/app/components/SearchSelect.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import {
+  TextInput,
+  Paper,
+  Stack,
+  Text,
+  Loader,
+  UnstyledButton,
+  Box,
+  ActionIcon,
+  Group,
+  ThemeIcon,
+} from '@mantine/core';
+import { IconX, IconCheck } from '@tabler/icons-react';
+import { useClickOutside } from '@mantine/hooks';
+import { useEffect, useState } from 'react';
+
+export interface SearchSelectOption<T = unknown> {
+  id: number | string;
+  label: string;
+  raw: T;
+}
+
+interface SearchSelectProps<T = unknown> {
+  endpoint: string;
+  label: string;
+  placeholder?: string;
+  limit?: number;
+  value?: SearchSelectOption<T> | null;
+  onChange: (value: SearchSelectOption<T> | null) => void;
+  clearable?: boolean;
+  mapResult: (item: T) => SearchSelectOption<T>;
+}
+
+export function SearchSelect<T = unknown>({
+  endpoint,
+  label,
+  placeholder = 'Search…',
+  limit = 5,
+  value,
+  onChange,
+  clearable = true,
+  mapResult,
+}: SearchSelectProps<T>) {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<SearchSelectOption<T>[]>([]);
+  const [opened, setOpened] = useState(false);
+
+  const ref = useClickOutside(() => setOpened(false));
+
+  const fetchResults = (search: string) => {
+    setLoading(true);
+
+    fetch(`${endpoint}?search=${encodeURIComponent(search)}&page_size=${limit}`)
+      .then((r) => r.json())
+      .then((data) => {
+        // normalize paginated vs array
+        const items: T[] = Array.isArray(data)
+          ? data
+          : Array.isArray(data.results)
+          ? data.results
+          : [];
+
+        setResults(items.slice(0, limit).map(mapResult));
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <Box pos="relative" ref={ref}>
+      <TextInput
+        label={label}
+        placeholder={placeholder}
+        value={opened ? query : value?.label || query}
+        onFocus={() => {
+          setOpened(true);
+          fetchResults('');
+        }}
+        onChange={(e) => {
+          setQuery(e.currentTarget.value);
+          onChange(null);
+        }}
+        rightSection={
+          loading ? (
+            <Loader size="xs" />
+          ) : (
+            value &&
+            clearable && (
+              <ActionIcon
+                size="sm"
+                variant="subtle"
+                onClick={() => {
+                  onChange(null);
+                  setQuery('');
+                  setOpened(false);
+                }}
+              >
+                <IconX size={14} />
+              </ActionIcon>
+            )
+          )
+        }
+      />
+
+      {opened && results.length > 0 && (
+        <Paper shadow="sm" withBorder mt={4} p="xs" pos="absolute" w="100%" style={{ zIndex: 10 }}>
+          <Stack gap={2}>
+            {results.map((option) => {
+              const selected = option.id === value?.id;
+
+              return (
+                <UnstyledButton
+                  key={option.id}
+                  onClick={() => {
+                    onChange(option);
+                    setOpened(false);
+                    setQuery('');
+                  }}
+                >
+                  <Group gap="xs">
+                    <Text size="sm" fw={selected ? 700 : 400}>
+                      {option.label}
+                    </Text>
+                  </Group>
+                </UnstyledButton>
+              );
+            })}
+          </Stack>
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/Application/app/components/TicketBulkCreateModal.tsx
+++ b/Application/app/components/TicketBulkCreateModal.tsx
@@ -1,0 +1,162 @@
+import {
+  Modal,
+  Select,
+  TextInput,
+  Textarea,
+  Button,
+  Group,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { useState } from "react";
+import getCookie from '@/app/utils/cookie';
+import { type TicketType } from '@/app/components/ticket-utils';
+import { SearchSelect, SearchSelectOption } from './SearchSelect';
+
+interface Event { id: number; name: string }
+interface User { id: number; name: string }
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+  contactIds: number[];
+  users: User[];
+  onSuccess?: () => void;
+}
+
+export function TicketBulkCreateModal({
+  opened,
+  onClose,
+  contactIds,
+  users,
+  onSuccess,
+}: Props) {
+  const [ticketType, setTicketType] = useState<SearchSelectOption | null>(null);
+  const [priority, setPriority] = useState<string | null>(null);
+  const [event, setEvent] = useState<SearchSelectOption | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [assignedToId, setAssignedToId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setLoading(true);
+    setError(null);
+
+    const payload: Record<string, unknown> = {
+      contact_ids: contactIds.map(Number),
+      ticket_type: ticketType?.id ?? "UNKNOWN",
+      ticket_status: "OPEN",
+      title,
+      description,
+    };
+
+    if (event) payload.event_id = Number(event.id);
+    if (assignedToId) payload.assigned_to_id = Number(assignedToId);
+    if (priority !== null) payload.priority = Number(priority);
+
+    try {
+      const res = await fetch("/api/tickets/bulk/", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": getCookie('csrftoken')!,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(JSON.stringify(data));
+      }
+
+      onSuccess?.();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Bulk Create Tickets" size="lg" centered>
+      <Stack gap="md">
+        {/* Ticket Type */}
+        <SearchSelect<TicketType>
+          endpoint="/api/ticket-types"
+          label="Ticket Type"
+          placeholder="Select ticket type"
+          limit={10}
+          value={ticketType}
+          onChange={setTicketType}
+          clearable
+          mapResult={(type) => ({
+            id: type.value,
+            label: type.label,
+            raw: type,
+          })}
+        />
+
+        {/* Priority */}
+        <Select
+          label="Priority"
+          placeholder="Default (P3)"
+          data={[
+            { value: "0", label: "P0 – Emergency" },
+            { value: "1", label: "P1 – Very High" },
+            { value: "2", label: "P2 – High" },
+            { value: "3", label: "P3 – Normal" },
+            { value: "4", label: "P4 – Low" },
+            { value: "5", label: "P5 – Very Low" },
+          ]}
+          value={priority}
+          onChange={setPriority}
+          clearable
+        />
+
+        {/* Event */}
+        <SearchSelect<Event>
+          endpoint="/api/events/"
+          label="Event"
+          placeholder="Search events"
+          limit={5}
+          value={event}
+          onChange={setEvent}
+          clearable
+          mapResult={(event) => ({
+            id: event.id,
+            label: `${event.name} (id: ${event.id})`,
+            raw: event,
+          })}
+        />
+
+        {/* Title / Description */}
+        <TextInput label="Title" value={title} onChange={(e) => setTitle(e.currentTarget.value)} />
+        <Textarea label="Description" minRows={3} value={description} onChange={(e) => setDescription(e.currentTarget.value)} />
+
+        {error && <Text c="red" size="sm">{error}</Text>}
+
+        {/* Footer */}
+        <Group justify="space-between" mt="md">
+          <Text size="sm" c="dimmed">
+            {contactIds.length === 0
+              ? "No tickets will be created"
+              : `${contactIds.length} ticket${contactIds.length !== 1 ? "s" : ""} will be created`}
+          </Text>
+
+          <Group>
+            <Button variant="default" onClick={onClose} disabled={loading}>
+              Cancel
+            </Button>
+            <Button onClick={submit} loading={loading} disabled={contactIds.length === 0}>
+              Create Tickets
+            </Button>
+          </Group>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/Application/app/components/TicketTable.tsx
+++ b/Application/app/components/TicketTable.tsx
@@ -7,7 +7,6 @@ import { Ticket } from './ticket-utils';
 interface TicketTableProps {
   tickets: Ticket[];
   loading?: boolean;
-  onRowClick?: (reach: Ticket) => void;
   showTitle?: boolean;
 }
 
@@ -34,7 +33,6 @@ export const getStatusColor = (status: string) => {
 export default function TicketTable({
   tickets: tickets,
   loading = false,
-  onRowClick,
   showTitle = true
 }: TicketTableProps) {
   const router = useRouter()
@@ -60,7 +58,7 @@ export default function TicketTable({
               <Table.Tr
                 key={ticket.id}
                 onClick={() => router.push(`/tickets/${ticket.id}`)}
-                style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                style={{ cursor: 'pointer' }}
               >
                 <Table.Td>{ticket.id}</Table.Td>
                 <Table.Td>{ticket.title}</Table.Td>

--- a/Application/app/components/ticket-utils.ts
+++ b/Application/app/components/ticket-utils.ts
@@ -1,3 +1,7 @@
+export interface TicketType {
+  value: string;
+  label: string;
+}
 
 export interface Ticket {
   id: number;

--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -17,11 +17,13 @@ import {
 import { IconPlus, IconFileUpload, IconSearch, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { useState, useEffect } from 'react';
 import { useForm } from '@mantine/form';
+import { TicketBulkCreateModal } from '@/app/components/TicketBulkCreateModal';
 import ContactTable, { type Contact, type Group as ContactGroup, type Tag } from '@/app/components/ContactTable';
 import './page.css';
 
 export default function ContactsPage() {
   const [contacts, setContacts] = useState<Contact[]>([]);
+  const [bulkTicketModalOpen, setBulkTicketModalOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedGroup, setSelectedGroup] = useState<string | null>('all');
@@ -279,6 +281,13 @@ export default function ContactsPage() {
                     {selectedRows.size} selected
                   </Text>
                   <Button
+                    size="xs"
+                    variant="light"
+                    onClick={() => setBulkTicketModalOpen(true)}
+                  >
+                    Create Tickets
+                  </Button>
+                  <Button
                     variant="subtle"
                     color="red"
                     size="xs"
@@ -367,6 +376,16 @@ export default function ContactsPage() {
           </Stack>
         </form>
       </Modal>
+      <TicketBulkCreateModal
+        opened={bulkTicketModalOpen}
+        onClose={() => setBulkTicketModalOpen(false)}
+        contactIds={Array.from(selectedRows)}
+        events={[]} // 🔧 plug in events once available
+        users={[]}  // 🔧 plug in users once available
+        onSuccess={() => {
+          setSelectedRows(new Set());
+        }}
+      />
     </Container>
   );
 }

--- a/Application/app/tickets/page.tsx
+++ b/Application/app/tickets/page.tsx
@@ -23,9 +23,8 @@ import ContactSearch from '@/app/components/ContactSearch';
 import { type Ticket } from '@/app/components/ticket-utils';
 
 // TODO: /tickets/123 doesn't work, we should make sure the url reflects the current ticket
-// TODO: Rename reaches/calls to use Ticket as name
 export default function TicketPage() {
-  const [reaches, setTicketes] = useState<Ticket[]>([]);
+  const [tickets, setTickets] = useState<Ticket[]>([]);
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState('in-progress');
@@ -52,13 +51,13 @@ export default function TicketPage() {
       const response = await fetch(fetchUrl);
       console.log('Fetch response:', response);
       const data = await response.json();
-      console.log('Fetched reaches data:', data);
-      setTicketes(data.results);
+      console.log('Fetched tickets data:', data);
+      setTickets(data.results || []);
       setTotalCount(data.count);
       setNextUrl(data.next);
       setPreviousUrl(data.previous);
     } catch (error) {
-      console.error('Error fetching reaches:', error);
+      console.error('Error fetching tickets:', error);
     } finally {
       setLoading(false);
     }
@@ -166,7 +165,7 @@ export default function TicketPage() {
             {/* Tickets Table or Call Instructions */}
               <>
                 <TicketTable
-                  tickets={reaches}
+                  tickets={tickets}
                   loading={loading}
                   onRowClick={handleRowClick}
                 />

--- a/Server/dggcrm/tickets/serializers.py
+++ b/Server/dggcrm/tickets/serializers.py
@@ -134,3 +134,7 @@ class BulkTicketCreateSerializer(serializers.Serializer):
             tickets.append(ticket)
 
         return Ticket.objects.bulk_create(tickets)
+
+class TicketTypeSerializer(serializers.Serializer):
+    value = serializers.CharField()
+    label = serializers.CharField()

--- a/Server/dggcrm/tickets/urls.py
+++ b/Server/dggcrm/tickets/urls.py
@@ -1,9 +1,10 @@
 from rest_framework.routers import DefaultRouter
 from django.urls import path, include
-from .views import TicketViewSet
+from .views import TicketViewSet, TicketTypeViewSet
 
 router = DefaultRouter()
 router.register('tickets', TicketViewSet, basename='ticket')
+router.register('ticket-types', TicketTypeViewSet, basename='ticket-types')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/Server/dggcrm/tickets/views.py
+++ b/Server/dggcrm/tickets/views.py
@@ -220,3 +220,8 @@ class TicketViewSet(viewsets.ModelViewSet):
         """
         user = self.request.user
         serializer.save(reported_by=user if user and user.is_authenticated else None)
+
+class TicketTypeViewSet(viewsets.ViewSet):
+    def list(self, request):
+        types = [{'value': t.value, 'label': t.label} for t in TicketType]
+        return Response(types)


### PR DESCRIPTION
Resolves #55

Adds bulk ticket creation modal. All it allows you to do is create a title + description for selected contacts. We can also add an optional event attached to the tickets. For now, there is no ticket template feature/templating for these tickets. I also created a SearchSelect component that allows you to quickly search and select some item generically from our APIs.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/9974252c-3375-49eb-9703-ff4a8f619677" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/9be0f5d6-a0c4-402f-a255-a524ece48455" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/f3fbedd1-e0c1-4905-ab08-15cb0205b90d" />

I added a new read-only API /api/ticket-types to make things easier when selecting the ticket type.
