### PR TITLE
Event Participation audit log now active

### DIFF
--- a/Application/app/components/TicketView.tsx
+++ b/Application/app/components/TicketView.tsx
@@ -1,21 +1,21 @@
 'use client'
 import Link from 'next/link';
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, JSX } from "react"
 import { Grid, Stack, Group, Title, Button, Paper, Box, Badge, Divider, Text, Timeline, Container, SegmentedControl, Loader, Center } from "@mantine/core"
 import { useRouter } from "next/navigation"
 import { getStatusColor, getPriorityColor } from "./TicketTable"
 import TicketDescription from "./TicketDescription";
 import { Ticket } from "./ticket-utils"
 import ContactSearch, { Contact } from "./ContactSearch"
-import { Event } from "./EventTable"
+import { Event } from "@/app/components/event-utils"
 import getCookie from '@/app/utils/cookie';
 import TicketActions from '@/app/components/tickets/TicketActions';
 
-type TimelineShowType = "both" | "request" | "audit";
+export type TimelineShowType = "all" | "request" | "audit" | "event_participation";
 
 interface TimelineEntry {
-  type: "audit" | "comment";
+  type: "audit" | "comment" | "event_participation";
   created_at: string;
   actor_display: string | null;
   actor_id: number | null;
@@ -303,10 +303,11 @@ function TicketTimeline({ timeline, loading, showType, onShowTypeChange }: Ticke
   };
 
   const getEntryTitle = (entry: TimelineEntry) => {
-    if (entry.type === "audit") {
-      return "Ticket updated";
+    switch (entry.type) {
+      case "audit": return "Ticket updated"
+      case "event_participation": return "Event Participation Changed"
+      default: return "Commend added"
     }
-    return "Comment added";
   };
 
   const renderChangeValue = (field: string, value: string) => {
@@ -325,9 +326,10 @@ function TicketTimeline({ timeline, loading, showType, onShowTypeChange }: Ticke
           value={showType}
           onChange={(value) => onShowTypeChange(value as TimelineShowType)}
           data={[
-            { label: 'All', value: 'both' },
+            { label: 'All', value: 'all' },
             { label: 'Comments', value: 'comment' },
             { label: 'Audit', value: 'audit' },
+            { label: 'Event Participation', value: 'event_participation'}
           ]}
         />
       </Group>
@@ -345,13 +347,10 @@ function TicketTimeline({ timeline, loading, showType, onShowTypeChange }: Ticke
                 <Text size="sm" mb={4}>{entry.message}</Text>
               )}
               {entry.type === "audit" && entry.changes && typeof entry.changes === 'object' && (
-                <Stack gap={2} mb={4}>
-                  {Object.entries(entry.changes).map(([field, [oldVal, newVal]]) => (
-                    <Text key={field} size="sm" c="dimmed">
-                      <Text span fw={500}>{field}:</Text> {renderChangeValue(field, oldVal)} → {renderChangeValue(field, newVal)}
-                    </Text>
-                  ))}
-                </Stack>
+                <AuditLogTimelineItem entry={entry} renderChangeValue={renderChangeValue}/>
+              )}
+              {entry.type === "event_participation" && entry.changes && typeof entry.changes === 'object' && (
+                <AuditLogTimelineItem entry={entry} renderChangeValue={renderChangeValue}/>
               )}
               <Text c="dimmed" size="sm">{entry.actor_display ?? 'System'}</Text>
               <Text size="xs" mt={4}>{formatDate(entry.created_at)}</Text>
@@ -361,6 +360,20 @@ function TicketTimeline({ timeline, loading, showType, onShowTypeChange }: Ticke
       )}
     </Paper>
   );
+}
+
+function AuditLogTimelineItem(
+  {entry, renderChangeValue}: {
+    entry: TimelineEntry,
+    renderChangeValue: (field: string, old: string) => string | JSX.Element
+  }) {
+  return <Stack gap={2} mb={4}>
+    {Object.entries(entry.changes!).map(([field, [oldVal, newVal]]) => (
+      <Text key={field} size="sm" c="dimmed">
+        <Text span fw={500}>{field}:</Text> {renderChangeValue(field, oldVal)} → {renderChangeValue(field, newVal)}
+      </Text>
+    ))}
+  </Stack>;
 }
 
 function Actions({ ticketId }: { ticketId: number }) {

--- a/Application/app/tickets/[id]/page.tsx
+++ b/Application/app/tickets/[id]/page.tsx
@@ -5,8 +5,7 @@ import { useParams } from "next/navigation";
 import TicketView from "@/app/components/TicketView";
 import { type Ticket } from "@/app/components/ticket-utils";
 import { Loader, Center, Text } from "@mantine/core";
-
-type TimelineShowType = "both" | "request" | "audit";
+import { type TimelineShowType } from "@/app/components/TicketView"
 
 interface TimelineEntry {
   type: "audit" | "comment";
@@ -26,7 +25,7 @@ export default function TicketInfoPage() {
 
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
   const [timelineLoading, setTimelineLoading] = useState(false);
-  const [showType, setShowType] = useState<TimelineShowType>("both");
+  const [showType, setShowType] = useState<TimelineShowType>("all");
 
   useEffect(() => {
     if (!id) return;

--- a/Server/dggcrm/events/apps.py
+++ b/Server/dggcrm/events/apps.py
@@ -1,7 +1,12 @@
 from django.apps import AppConfig
 
-
 class EventsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "dggcrm.events"
     verbose_name = "CRM.events"
+
+    def ready(self):
+        from auditlog.registry import auditlog
+
+        from .models import EventParticipation
+        auditlog.register(EventParticipation)

--- a/Server/dggcrm/events/models.py
+++ b/Server/dggcrm/events/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.conf import settings
+from auditlog.models import AuditlogHistoryField
 
 class EventStatus(models.TextChoices):
     DRAFT = "draft", "Draft"
@@ -84,6 +85,7 @@ class EventParticipation(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     modified_at = models.DateTimeField(auto_now=True)
+    history = AuditlogHistoryField()
 
     class Meta:
         db_table = "event_participations"

--- a/Server/dggcrm/tickets/views.py
+++ b/Server/dggcrm/tickets/views.py
@@ -10,6 +10,7 @@ from django.http import HttpResponseBadRequest
 from django.db.models import Count, Q, F
 from django.contrib.contenttypes.models import ContentType
 
+from ..events.models import EventParticipation
 from .models import Ticket, TicketStatus, TicketType, TicketComment, TicketAskStatus, TicketAsks
 from .serializers import TicketSerializer, BulkTicketCreateSerializer, TicketClaimSerializer, TicketCommentSerializer, TicketTimelineSerializer, TicketAskSerializer
 
@@ -209,25 +210,32 @@ class TicketViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["get"])
     def timeline(self, request, pk=None):
         ticket = self.get_object()
-        show_type = self.request.query_params.get("show", "both").lower()
+        show_type = self.request.query_params.get("show", "all").lower()
 
-        print("show_type", show_type)
-
-        audit_entries = []
+        ticket_audit_entries = []
         comments = []
+        event_participation_audit_entries = []
 
-        if show_type in ["audit", "both"]:
-            audit_entries = LogEntry.objects.filter(
+        if show_type in ["audit", "all"]:
+            ticket_audit_entries = LogEntry.objects.filter(
                 content_type=ContentType.objects.get_for_model(Ticket),
                 object_pk=ticket.pk,
             )
 
-        if show_type in ["comment", "both"]:
+        if show_type in ["comment", "all"]:
             comments = ticket.comments.all()
+        
+        if show_type in ["event_participation", "all"]:
+            try:
+                event_participation = EventParticipation.objects.get(event=ticket.event, contact=ticket.contact)
+                event_participation_audit_entries = event_participation.history.all()
+            except:
+                print(f"No event participations for {ticket.contact.full_name}", flush=True)
+                pass
 
         combined_entries = []
 
-        for log in audit_entries:
+        for log in ticket_audit_entries:
             combined_entries.append({
                 "type": "audit",
                 "created_at": log.timestamp,
@@ -243,6 +251,15 @@ class TicketViewSet(viewsets.ModelViewSet):
                 "actor_display": comment.author.username if comment.author else None,
                 "actor_id": comment.author.id if comment.author else None,
                 "message": comment.message,
+            })
+        for event_participation in event_participation_audit_entries:
+            print(event_participation, flush=True)
+            combined_entries.append({
+                "type": "event_participation",
+                "created_at": event_participation.timestamp,
+                "actor_display": event_participation.actor.username if event_participation.actor else None,
+                "actor_id": event_participation.actor.id if event_participation.actor else None,
+                "changes": event_participation.changes or log.object_repr,
             })
 
         # Sort newest first


### PR DESCRIPTION
<img width="1421" height="642" alt="image" src="https://github.com/user-attachments/assets/1232d536-0f00-44f4-891c-4c44f22c03db" />
closes #73 

chose implementation 4 for now as discussed in #73. If we think implementation 4 shows too many events we can always filter some out on the backend