### PR TITLE
Fix missing ending slash

### DIFF
--- a/Application/app/components/tickets/TicketView.tsx
+++ b/Application/app/components/tickets/TicketView.tsx
@@ -70,7 +70,7 @@ export default function TicketView({
       try {
         if (ticket.contact) {
           try {
-            setContact(await apiClient.get(`/contacts/${ticket.contact}`));
+            setContact(await apiClient.get(`/contacts/${ticket.contact}/`));
           } catch {
             setContact(null);
           }
@@ -78,7 +78,7 @@ export default function TicketView({
 
         if (ticket.event) {
           try {
-            setEvent(await apiClient.get(`/events/${ticket.event}`));
+            setEvent(await apiClient.get(`/events/${ticket.event}/`));
           } catch {
             setEvent(null);
           }
@@ -195,7 +195,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
   const upsertTicketStatus = async (status: EnumSelectOption<TicketType> | null) => {
     if (!status) return;
     try {
-      await apiClient.patch(`/tickets/${ticket.id}`, {
+      await apiClient.patch(`/tickets/${ticket.id}/`, {
         ticket_status: status.id,
       });
       setTicketStatus(status);

--- a/Application/app/components/tickets/TicketView.tsx
+++ b/Application/app/components/tickets/TicketView.tsx
@@ -179,9 +179,9 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
     setLoading(true);
     try {
       if (isClaimed) {
-        await apiClient.delete(`/tickets/${ticket.id}/claim`);
+        await apiClient.delete(`/tickets/${ticket.id}/claim/`);
       } else {
-        await apiClient.post(`/tickets/${ticket.id}/claim`, {});
+        await apiClient.post(`/tickets/${ticket.id}/claim/`, {});
       }
       window.location.reload();
     } catch (err) {


### PR DESCRIPTION
We get errors in production without this trailing slash

```
You called this URL via POST, but the URL doesn't end in a slash and you have APPEND_SLASH set. Django can't redirect to the slash URL while maintaining POST data. Change your form to point to house.digitalgroundgame.org/api/tickets/1/claim/ (note the trailing slash), or set APPEND_SLASH=False in your Django settings.
```