### PR TITLE
feat: add inline editing to event detail page

### DIFF
--- a/Application/app/components/EventsTable.tsx
+++ b/Application/app/components/EventsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Table, Stack, Title, LoadingOverlay, Paper, Text } from "@mantine/core";
+import { Table, Stack, Title, LoadingOverlay, Paper, Text, Checkbox } from "@mantine/core";
 import { useRouter } from "next/navigation";
 import { Event } from "./event-utils";
 import { DateRange } from "@/app/components/datetime";
@@ -8,17 +8,44 @@ import { DateRange } from "@/app/components/datetime";
 interface EventsTableProps {
   events: Event[];
   loading?: boolean;
-  onRowClick?: (event: Event) => void;
   showTitle?: boolean;
+  isSelectable?: boolean;
+  selectedIds?: Set<number>;
+  toggleSelect?: (id: number) => void;
 }
 
 export default function EventsTable({
   events,
   loading = false,
-  onRowClick,
   showTitle = true,
+  isSelectable = false,
+  selectedIds,
+  toggleSelect,
 }: EventsTableProps) {
   const router = useRouter();
+
+  const allOnPageSelected =
+    isSelectable && events.length > 0 && events.every((e) => selectedIds?.has(e.id));
+
+  const someOnPageSelected = isSelectable && events.some((e) => selectedIds?.has(e.id));
+
+  const toggleSelectAllOnPage = () => {
+    if (!toggleSelect || !selectedIds) return;
+
+    if (allOnPageSelected) {
+      events.forEach((e) => {
+        if (selectedIds.has(e.id)) {
+          toggleSelect(e.id);
+        }
+      });
+    } else {
+      events.forEach((e) => {
+        if (!selectedIds.has(e.id)) {
+          toggleSelect(e.id);
+        }
+      });
+    }
+  };
 
   return (
     <Paper p="md" withBorder style={{ position: "relative", minHeight: "400px" }}>
@@ -28,6 +55,15 @@ export default function EventsTable({
         <Table highlightOnHover>
           <Table.Thead>
             <Table.Tr>
+              {isSelectable && (
+                <Table.Th w={40}>
+                  <Checkbox
+                    checked={allOnPageSelected}
+                    indeterminate={someOnPageSelected && !allOnPageSelected}
+                    onChange={toggleSelectAllOnPage}
+                  />
+                </Table.Th>
+              )}
               <Table.Th>Event Name</Table.Th>
               <Table.Th>Status</Table.Th>
               <Table.Th>Date</Table.Th>
@@ -37,45 +73,61 @@ export default function EventsTable({
           <Table.Tbody>
             {events.length === 0 ? (
               <Table.Tr>
-                <Table.Td key={0} colSpan={5} style={{ textAlign: "center" }}>
+                <Table.Td colSpan={isSelectable ? 5 : 4} style={{ textAlign: "center" }}>
                   <Text c="dimmed" py="xl">
                     No events found.
                   </Text>
                 </Table.Td>
               </Table.Tr>
             ) : (
-              events.map((event) => (
-                <Table.Tr
-                  key={event.id}
-                  onClick={() => router.push(`/events/${event.id}`)}
-                  style={{ cursor: onRowClick ? "pointer" : "default" }}
-                >
-                  <Table.Td>
-                    <Text size="sm" fw={500}>
-                      {event.name}
-                    </Text>
-                    {event.description && (
-                      <Text size="xs" c="dimmed" lineClamp={1}>
-                        {event.description}
-                      </Text>
+              events.map((event) => {
+                const selected = selectedIds?.has(event.id);
+
+                return (
+                  <Table.Tr
+                    key={event.id}
+                    bg={selected ? "var(--mantine-color-blue-light)" : undefined}
+                    onClick={() => {
+                      if (isSelectable && toggleSelect && selectedIds?.size) {
+                        toggleSelect(event.id);
+                      } else {
+                        router.push(`/events/${event.id}`);
+                      }
+                    }}
+                    style={{ cursor: "pointer" }}
+                  >
+                    {isSelectable && (
+                      <Table.Td onClick={(e) => e.stopPropagation()}>
+                        <Checkbox checked={selected} onChange={() => toggleSelect!(event.id)} />
+                      </Table.Td>
                     )}
-                  </Table.Td>
-                  <Table.Td>
-                    <Text size="sm">{event.status_display}</Text>
-                  </Table.Td>
-                  <Table.Td>
-                    <DateRange
-                      start={event.starts_at}
-                      end={event.ends_at}
-                      size="sm"
-                      format="medium"
-                    />
-                  </Table.Td>
-                  <Table.Td>
-                    <Text size="sm">{event.location_display}</Text>
-                  </Table.Td>
-                </Table.Tr>
-              ))
+                    <Table.Td>
+                      <Text size="sm" fw={500}>
+                        {event.name}
+                      </Text>
+                      {event.description && (
+                        <Text size="xs" c="dimmed" lineClamp={1}>
+                          {event.description}
+                        </Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm">{event.status_display}</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <DateRange
+                        start={event.starts_at}
+                        end={event.ends_at}
+                        size="sm"
+                        format="medium"
+                      />
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="sm">{event.location_display}</Text>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })
             )}
           </Table.Tbody>
         </Table>

--- a/Application/app/components/inline-edit/InlineDatetime.tsx
+++ b/Application/app/components/inline-edit/InlineDatetime.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { TextInput } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+import { InlineEdit, makeUnstyled } from "./InlineEdit";
+
+export interface InlineDatetimeProps {
+  value: string;
+  onSave: (value: string) => void;
+  displayComponent: React.ReactNode;
+}
+
+export function InlineDatetime({ value, onSave, displayComponent }: InlineDatetimeProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const handleSave = () => {
+    if (draft !== value) {
+      onSave(draft);
+    }
+    setEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraft(value);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  return (
+    <InlineEdit
+      editing={editing}
+      onStartEdit={() => {
+        setDraft(value);
+        setEditing(true);
+      }}
+      displayComponent={displayComponent}
+    >
+      <TextInput
+        ref={inputRef}
+        type="datetime-local"
+        value={draft}
+        onChange={(e) => setDraft(e.currentTarget.value)}
+        onBlur={handleSave}
+        onKeyDown={handleKeyDown}
+        styles={makeUnstyled()}
+      />
+    </InlineEdit>
+  );
+}

--- a/Application/app/components/inline-edit/InlineEdit.tsx
+++ b/Application/app/components/inline-edit/InlineEdit.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Box } from "@mantine/core";
+
+export interface InlineEditProps {
+  editing: boolean;
+  onStartEdit: () => void;
+  displayComponent: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function InlineEdit({ editing, onStartEdit, displayComponent, children }: InlineEditProps) {
+  if (editing) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Box style={{ cursor: "pointer" }} onClick={onStartEdit}>
+      {displayComponent}
+    </Box>
+  );
+}
+
+export function makeUnstyled(fontSize?: string, fontWeight?: string, forTextarea = false) {
+  const base: Record<string, string | number> = {
+    border: "none",
+    background: "transparent",
+    padding: 0,
+    margin: 0,
+    lineHeight: "inherit",
+    fontSize: fontSize ?? "inherit",
+    fontWeight: fontWeight ?? "inherit",
+    fontFamily: "inherit",
+    color: "inherit",
+  };
+  if (!forTextarea) {
+    base.height = "auto";
+    base.minHeight = "unset";
+  }
+  return { input: base };
+}

--- a/Application/app/components/inline-edit/InlineSelect.tsx
+++ b/Application/app/components/inline-edit/InlineSelect.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Select } from "@mantine/core";
+import { useState } from "react";
+import { InlineEdit } from "./InlineEdit";
+
+export interface InlineSelectProps {
+  value: string;
+  onSave: (value: string) => void;
+  options: { label: string; value: string }[];
+  displayComponent: React.ReactNode;
+}
+
+export function InlineSelect({ value, onSave, options, displayComponent }: InlineSelectProps) {
+  const [editing, setEditing] = useState(false);
+
+  return (
+    <InlineEdit
+      editing={editing}
+      onStartEdit={() => setEditing(true)}
+      displayComponent={displayComponent}
+    >
+      <Select
+        data={options}
+        value={value}
+        onChange={(v) => {
+          if (v !== null) {
+            onSave(v);
+          }
+          setEditing(false);
+        }}
+        allowDeselect={false}
+        defaultDropdownOpened
+        onDropdownClose={() => setEditing(false)}
+        size="xs"
+      />
+    </InlineEdit>
+  );
+}

--- a/Application/app/components/inline-edit/InlineText.tsx
+++ b/Application/app/components/inline-edit/InlineText.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { TextInput } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+import { InlineEdit, makeUnstyled } from "./InlineEdit";
+
+export interface InlineTextProps {
+  value: string;
+  onSave: (value: string) => void;
+  displayComponent: React.ReactNode;
+  fontSize?: string;
+  fontWeight?: string;
+}
+
+export function InlineText({
+  value,
+  onSave,
+  displayComponent,
+  fontSize,
+  fontWeight,
+}: InlineTextProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const handleSave = () => {
+    if (draft !== value) {
+      onSave(draft);
+    }
+    setEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraft(value);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  return (
+    <InlineEdit
+      editing={editing}
+      onStartEdit={() => {
+        setDraft(value);
+        setEditing(true);
+      }}
+      displayComponent={displayComponent}
+    >
+      <TextInput
+        ref={inputRef}
+        value={draft}
+        onChange={(e) => setDraft(e.currentTarget.value)}
+        onBlur={handleSave}
+        onKeyDown={handleKeyDown}
+        styles={makeUnstyled(fontSize, fontWeight)}
+      />
+    </InlineEdit>
+  );
+}

--- a/Application/app/components/inline-edit/InlineTextarea.tsx
+++ b/Application/app/components/inline-edit/InlineTextarea.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Textarea } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+import { InlineEdit, makeUnstyled } from "./InlineEdit";
+
+export interface InlineTextareaProps {
+  value: string;
+  onSave: (value: string) => void;
+  displayComponent: React.ReactNode;
+  fontSize?: string;
+  fontWeight?: string;
+}
+
+export function InlineTextarea({
+  value,
+  onSave,
+  displayComponent,
+  fontSize,
+  fontWeight,
+}: InlineTextareaProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const handleSave = () => {
+    if (draft !== value) {
+      onSave(draft);
+    }
+    setEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraft(value);
+    setEditing(false);
+  };
+
+  return (
+    <InlineEdit
+      editing={editing}
+      onStartEdit={() => {
+        setDraft(value);
+        setEditing(true);
+      }}
+      displayComponent={displayComponent}
+    >
+      <Textarea
+        ref={inputRef}
+        value={draft}
+        onChange={(e) => setDraft(e.currentTarget.value)}
+        onBlur={handleSave}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") handleCancel();
+        }}
+        minRows={1}
+        autosize
+        styles={makeUnstyled(fontSize, fontWeight, true)}
+      />
+    </InlineEdit>
+  );
+}

--- a/Application/app/components/inline-edit/index.ts
+++ b/Application/app/components/inline-edit/index.ts
@@ -1,0 +1,5 @@
+export { InlineEdit, type InlineEditProps } from "./InlineEdit";
+export { InlineText, type InlineTextProps } from "./InlineText";
+export { InlineTextarea, type InlineTextareaProps } from "./InlineTextarea";
+export { InlineSelect, type InlineSelectProps } from "./InlineSelect";
+export { InlineDatetime, type InlineDatetimeProps } from "./InlineDatetime";

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -1,4 +1,10 @@
 import { Contact } from "@/app/components/ContactSearch";
+import {
+  InlineDatetime,
+  InlineSelect,
+  InlineText,
+  InlineTextarea,
+} from "@/app/components/inline-edit";
 import PaginatedTable from "@/app/components/pagination/PaginatedTable";
 import PaginationBar, {
   decrementPageSearchParam,
@@ -22,150 +28,12 @@ import {
   LoadingOverlay,
   Table,
   TextInput,
-  Textarea,
-  Select,
   Group,
   MultiSelect,
 } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
-
-interface StatusOption {
-  label: string;
-  value: string;
-}
-
-function makeUnstyled(fontSize?: string, fontWeight?: string, forTextarea = false) {
-  const base: Record<string, string | number> = {
-    border: "none",
-    background: "transparent",
-    padding: 0,
-    margin: 0,
-    lineHeight: "inherit",
-    fontSize: fontSize ?? "inherit",
-    fontWeight: fontWeight ?? "inherit",
-    fontFamily: "inherit",
-    color: "inherit",
-  };
-  if (!forTextarea) {
-    base.height = "auto";
-    base.minHeight = "unset";
-  }
-  return { input: base };
-}
-
-function InlineEdit({
-  value,
-  onSave,
-  type = "text",
-  options,
-  displayComponent,
-  fontSize,
-  fontWeight,
-}: {
-  value: string;
-  onSave: (value: string) => void;
-  type?: "text" | "textarea" | "select" | "datetime-local";
-  options?: { label: string; value: string }[];
-  displayComponent: React.ReactNode;
-  fontSize?: string;
-  fontWeight?: string;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(value);
-  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    if (editing && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
-    }
-  }, [editing]);
-
-  const handleSave = () => {
-    if (draft !== value) {
-      onSave(draft);
-    }
-    setEditing(false);
-  };
-
-  const handleCancel = () => {
-    setDraft(value);
-    setEditing(false);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && type !== "textarea") {
-      e.preventDefault();
-      handleSave();
-    } else if (e.key === "Escape") {
-      handleCancel();
-    }
-  };
-
-  if (!editing) {
-    return (
-      <Box
-        style={{ cursor: "pointer" }}
-        onClick={() => {
-          setDraft(value);
-          setEditing(true);
-        }}
-      >
-        {displayComponent}
-      </Box>
-    );
-  }
-
-  if (type === "select") {
-    return (
-      <Select
-        data={options}
-        value={draft}
-        onChange={(v) => {
-          if (v !== null) {
-            onSave(v);
-          }
-          setEditing(false);
-        }}
-        allowDeselect={false}
-        defaultDropdownOpened
-        onDropdownClose={() => setEditing(false)}
-        size="xs"
-      />
-    );
-  }
-
-  if (type === "textarea") {
-    return (
-      <Textarea
-        ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-        value={draft}
-        onChange={(e) => setDraft(e.currentTarget.value)}
-        onBlur={handleSave}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") handleCancel();
-        }}
-        minRows={1}
-        autosize
-        styles={makeUnstyled(fontSize, fontWeight, true)}
-      />
-    );
-  }
-
-  return (
-    <TextInput
-      ref={inputRef as React.RefObject<HTMLInputElement>}
-      type={type}
-      value={draft}
-      onChange={(e) => setDraft(e.currentTarget.value)}
-      onBlur={handleSave}
-      onKeyDown={handleKeyDown}
-      styles={makeUnstyled(fontSize, fontWeight)}
-    />
-  );
-}
+import { useState } from "react";
 
 export default function EventView({
   event,
@@ -183,7 +51,8 @@ export default function EventView({
 }
 
 function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }) {
-  const { data: eventStatuses } = useBackend<StatusOption[]>("/api/event-statuses/");
+  const { data: eventStatuses } =
+    useBackend<{ label: string; value: string }[]>("/api/event-statuses/");
 
   const handleSave = async (field: string, value: string) => {
     try {
@@ -203,7 +72,7 @@ function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }
       <GridCol span={{ base: 12, md: 8 }}>
         <Paper withBorder p="md">
           <Stack gap="sm">
-            <InlineEdit
+            <InlineText
               value={event.name}
               onSave={(v) => handleSave("name", v)}
               displayComponent={<Title>{event.name}</Title>}
@@ -211,8 +80,7 @@ function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }
               fontWeight="bold"
             />
             <Divider />
-            <InlineEdit
-              type="textarea"
+            <InlineTextarea
               value={event.description ?? ""}
               onSave={(v) => handleSave("description", v)}
               displayComponent={<Text>{event.description || "No description"}</Text>}
@@ -233,7 +101,7 @@ function EventViewMetadata({
 }: {
   event: Event;
   onSave: (field: string, value: string) => void;
-  statusOptions?: StatusOption[];
+  statusOptions?: { label: string; value: string }[];
 }) {
   return (
     <GridCol span={{ base: 12, md: 4 }}>
@@ -242,10 +110,9 @@ function EventViewMetadata({
           <Text c="dimmed" size="sm">
             Event Status
           </Text>
-          <InlineEdit
-            type="select"
+          <InlineSelect
             value={event.event_status}
-            options={statusOptions}
+            options={statusOptions ?? []}
             onSave={(v) => onSave("event_status", v)}
             displayComponent={
               <Badge color={getEventStatusColor(event.status_display)}>
@@ -259,7 +126,7 @@ function EventViewMetadata({
           <Text c="dimmed" size="sm">
             Location Name
           </Text>
-          <InlineEdit
+          <InlineText
             value={event.location_name ?? ""}
             onSave={(v) => onSave("location_name", v)}
             displayComponent={<Text>{event.location_name || "—"}</Text>}
@@ -270,7 +137,7 @@ function EventViewMetadata({
           <Text c="dimmed" size="sm">
             Address
           </Text>
-          <InlineEdit
+          <InlineText
             value={event.location_address ?? ""}
             onSave={(v) => onSave("location_address", v)}
             displayComponent={<Text>{event.location_address || "—"}</Text>}
@@ -281,8 +148,7 @@ function EventViewMetadata({
           <Text c="dimmed" size="sm">
             Start Date
           </Text>
-          <InlineEdit
-            type="datetime-local"
+          <InlineDatetime
             value={event.starts_at ?? ""}
             onSave={(v) => onSave("starts_at", v)}
             displayComponent={<Text>{event.starts_at || "—"}</Text>}
@@ -293,8 +159,7 @@ function EventViewMetadata({
           <Text c="dimmed" size="sm">
             End Date
           </Text>
-          <InlineEdit
-            type="datetime-local"
+          <InlineDatetime
             value={event.ends_at ?? ""}
             onSave={(v) => onSave("ends_at", v)}
             displayComponent={<Text>{event.ends_at || "—"}</Text>}

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -7,7 +7,7 @@ import PaginationBar, {
 import { formatContactInfo } from "@/app/components/contact-utils";
 import { Event, getStatusColor as getEventStatusColor } from "@/app/components/event-utils";
 import { BackendPaginatedResults, useBackend } from "@/app/lib/api";
-import { apiClient } from "@/app/lib/apiClient";
+import { ApiError, apiClient } from "@/app/lib/apiClient";
 import {
   Text,
   Paper,
@@ -31,12 +31,10 @@ import { IconSearch } from "@tabler/icons-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
-const EVENT_STATUS_OPTIONS = [
-  { label: "Draft", value: "draft" },
-  { label: "Scheduled", value: "scheduled" },
-  { label: "Completed", value: "completed" },
-  { label: "Canceled", value: "canceled" },
-];
+interface StatusOption {
+  label: string;
+  value: string;
+}
 
 function makeUnstyled(fontSize?: string, fontWeight?: string, forTextarea = false) {
   const base: Record<string, string | number> = {
@@ -185,9 +183,19 @@ export default function EventView({
 }
 
 function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }) {
+  const { data: eventStatuses } = useBackend<StatusOption[]>("/api/event-statuses/");
+
   const handleSave = async (field: string, value: string) => {
-    await apiClient.patch(`/events/${event.id}/`, { [field]: value });
-    refresh();
+    try {
+      await apiClient.patch(`/events/${event.id}/`, { [field]: value });
+      refresh();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        alert("User does not have permission to edit this event.");
+      } else {
+        alert("Failed to save changes.");
+      }
+    }
   };
 
   return (
@@ -213,7 +221,7 @@ function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }
         </Paper>
         <EventViewContactTable event={event} />
       </GridCol>
-      <EventViewMetadata event={event} onSave={handleSave} />
+      <EventViewMetadata event={event} onSave={handleSave} statusOptions={eventStatuses} />
     </Grid>
   );
 }
@@ -221,9 +229,11 @@ function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }
 function EventViewMetadata({
   event,
   onSave,
+  statusOptions,
 }: {
   event: Event;
   onSave: (field: string, value: string) => void;
+  statusOptions?: StatusOption[];
 }) {
   return (
     <GridCol span={{ base: 12, md: 4 }}>
@@ -235,7 +245,7 @@ function EventViewMetadata({
           <InlineEdit
             type="select"
             value={event.event_status}
-            options={EVENT_STATUS_OPTIONS}
+            options={statusOptions}
             onSave={(v) => onSave("event_status", v)}
             displayComponent={
               <Badge color={getEventStatusColor(event.status_display)}>

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -5,8 +5,9 @@ import PaginationBar, {
   incrementPageSearchParam,
 } from "@/app/components/pagination/PaginationBar";
 import { formatContactInfo } from "@/app/components/contact-utils";
-import { Event } from "@/app/components/event-utils";
+import { Event, getStatusColor as getEventStatusColor } from "@/app/components/event-utils";
 import { BackendPaginatedResults, useBackend } from "@/app/lib/api";
+import { apiClient } from "@/app/lib/apiClient";
 import {
   Text,
   Paper,
@@ -21,41 +22,209 @@ import {
   LoadingOverlay,
   Table,
   TextInput,
+  Textarea,
+  Select,
   Group,
   MultiSelect,
 } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-export default function EventView({ event }: { event: Event | undefined }) {
+const EVENT_STATUS_OPTIONS = [
+  { label: "Draft", value: "draft" },
+  { label: "Scheduled", value: "scheduled" },
+  { label: "Completed", value: "completed" },
+  { label: "Canceled", value: "canceled" },
+];
+
+function makeUnstyled(fontSize?: string, fontWeight?: string, forTextarea = false) {
+  const base: Record<string, string | number> = {
+    border: "none",
+    background: "transparent",
+    padding: 0,
+    margin: 0,
+    lineHeight: "inherit",
+    fontSize: fontSize ?? "inherit",
+    fontWeight: fontWeight ?? "inherit",
+    fontFamily: "inherit",
+    color: "inherit",
+  };
+  if (!forTextarea) {
+    base.height = "auto";
+    base.minHeight = "unset";
+  }
+  return { input: base };
+}
+
+function InlineEdit({
+  value,
+  onSave,
+  type = "text",
+  options,
+  displayComponent,
+  fontSize,
+  fontWeight,
+}: {
+  value: string;
+  onSave: (value: string) => void;
+  type?: "text" | "textarea" | "select" | "datetime-local";
+  options?: { label: string; value: string }[];
+  displayComponent: React.ReactNode;
+  fontSize?: string;
+  fontWeight?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const handleSave = () => {
+    if (draft !== value) {
+      onSave(draft);
+    }
+    setEditing(false);
+  };
+
+  const handleCancel = () => {
+    setDraft(value);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && type !== "textarea") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      handleCancel();
+    }
+  };
+
+  if (!editing) {
+    return (
+      <Box
+        style={{ cursor: "pointer" }}
+        onClick={() => {
+          setDraft(value);
+          setEditing(true);
+        }}
+      >
+        {displayComponent}
+      </Box>
+    );
+  }
+
+  if (type === "select") {
+    return (
+      <Select
+        data={options}
+        value={draft}
+        onChange={(v) => {
+          if (v !== null) {
+            onSave(v);
+          }
+          setEditing(false);
+        }}
+        allowDeselect={false}
+        defaultDropdownOpened
+        onDropdownClose={() => setEditing(false)}
+        size="xs"
+      />
+    );
+  }
+
+  if (type === "textarea") {
+    return (
+      <Textarea
+        ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+        value={draft}
+        onChange={(e) => setDraft(e.currentTarget.value)}
+        onBlur={handleSave}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") handleCancel();
+        }}
+        minRows={1}
+        autosize
+        styles={makeUnstyled(fontSize, fontWeight, true)}
+      />
+    );
+  }
+
+  return (
+    <TextInput
+      ref={inputRef as React.RefObject<HTMLInputElement>}
+      type={type}
+      value={draft}
+      onChange={(e) => setDraft(e.currentTarget.value)}
+      onBlur={handleSave}
+      onKeyDown={handleKeyDown}
+      styles={makeUnstyled(fontSize, fontWeight)}
+    />
+  );
+}
+
+export default function EventView({
+  event,
+  refresh,
+}: {
+  event: Event | undefined;
+  refresh: () => void;
+}) {
   return (
     <Container py="xl" size="xl">
       <LoadingOverlay visible={!event} />
-      {event && <EventViewMain event={event} />}
+      {event && <EventViewMain event={event} refresh={refresh} />}
     </Container>
   );
 }
 
-function EventViewMain({ event }: { event: Event }) {
+function EventViewMain({ event, refresh }: { event: Event; refresh: () => void }) {
+  const handleSave = async (field: string, value: string) => {
+    await apiClient.patch(`/events/${event.id}/`, { [field]: value });
+    refresh();
+  };
+
   return (
     <Grid>
       <GridCol span={{ base: 12, md: 8 }}>
         <Paper withBorder p="md">
           <Stack gap="sm">
-            <Title>{event.name}</Title>
+            <InlineEdit
+              value={event.name}
+              onSave={(v) => handleSave("name", v)}
+              displayComponent={<Title>{event.name}</Title>}
+              fontSize="var(--mantine-h1-font-size)"
+              fontWeight="bold"
+            />
             <Divider />
-            <Text>{event.description}</Text>
+            <InlineEdit
+              type="textarea"
+              value={event.description ?? ""}
+              onSave={(v) => handleSave("description", v)}
+              displayComponent={<Text>{event.description || "No description"}</Text>}
+            />
           </Stack>
         </Paper>
         <EventViewContactTable event={event} />
       </GridCol>
-      <EventViewMetadata event={event} />
+      <EventViewMetadata event={event} onSave={handleSave} />
     </Grid>
   );
 }
 
-function EventViewMetadata({ event }: { event: Event }) {
+function EventViewMetadata({
+  event,
+  onSave,
+}: {
+  event: Event;
+  onSave: (field: string, value: string) => void;
+}) {
   return (
     <GridCol span={{ base: 12, md: 4 }}>
       <Paper withBorder p="sm">
@@ -63,42 +232,63 @@ function EventViewMetadata({ event }: { event: Event }) {
           <Text c="dimmed" size="sm">
             Event Status
           </Text>
-          <Badge color={getStatusColor(event.status_display)}>{event.status_display}</Badge>
+          <InlineEdit
+            type="select"
+            value={event.event_status}
+            options={EVENT_STATUS_OPTIONS}
+            onSave={(v) => onSave("event_status", v)}
+            displayComponent={
+              <Badge color={getEventStatusColor(event.status_display)}>
+                {event.status_display}
+              </Badge>
+            }
+          />
         </Box>
         <Divider />
         <Box mt={4} mb={4}>
           <Text c="dimmed" size="sm">
             Location Name
           </Text>
-          <Text>{event.location_name}</Text>
+          <InlineEdit
+            value={event.location_name ?? ""}
+            onSave={(v) => onSave("location_name", v)}
+            displayComponent={<Text>{event.location_name || "—"}</Text>}
+          />
         </Box>
         <Divider />
         <Box mt={4} mb={4}>
           <Text c="dimmed" size="sm">
             Address
           </Text>
-          <Text mb={4}>{event.location_address}</Text>
-        </Box>
-        <Divider />
-        <Box mt={4} mb={4}>
-          <Text c="dimmed" size="sm">
-            Location Display
-          </Text>
-          <Text>{event.location_display}</Text>
+          <InlineEdit
+            value={event.location_address ?? ""}
+            onSave={(v) => onSave("location_address", v)}
+            displayComponent={<Text>{event.location_address || "—"}</Text>}
+          />
         </Box>
         <Divider />
         <Box mt={4} mb={4}>
           <Text c="dimmed" size="sm">
             Start Date
           </Text>
-          <Text>{event.starts_at}</Text>
+          <InlineEdit
+            type="datetime-local"
+            value={event.starts_at ?? ""}
+            onSave={(v) => onSave("starts_at", v)}
+            displayComponent={<Text>{event.starts_at || "—"}</Text>}
+          />
         </Box>
         <Divider />
         <Box mt={4} mb={4}>
           <Text c="dimmed" size="sm">
             End Date
           </Text>
-          <Text>{event.ends_at}</Text>
+          <InlineEdit
+            type="datetime-local"
+            value={event.ends_at ?? ""}
+            onSave={(v) => onSave("ends_at", v)}
+            displayComponent={<Text>{event.ends_at || "—"}</Text>}
+          />
         </Box>
       </Paper>
     </GridCol>

--- a/Application/app/events/[id]/page.tsx
+++ b/Application/app/events/[id]/page.tsx
@@ -2,16 +2,15 @@
 import { Event } from "@/app/components/event-utils";
 import EventView from "@/app/events/[id]/EventView";
 import { useBackend } from "@/app/lib/api";
-import { useEffect, useState, use } from "react";
+import { use } from "react";
 
 export default function EventDetailsPage({ params }: { params: Promise<{ id: string }> }) {
-  // const [eventDetail, setEventDetail] = useState<Event>();
   const { id } = use(params);
-  const { data: eventDetail, loading, error } = useBackend<Event>(`/api/events/${id}`);
+  const { data: eventDetail, refresh } = useBackend<Event>(`/api/events/${id}/`);
 
   return (
     <>
-      <EventView event={eventDetail} />
+      <EventView event={eventDetail} refresh={refresh} />
     </>
   );
 }

--- a/Application/app/events/page.tsx
+++ b/Application/app/events/page.tsx
@@ -7,20 +7,25 @@ import {
   Button,
   Paper,
   TextInput,
-  Select,
   Stack,
   Modal,
   Textarea,
   Text,
   ActionIcon,
+  Menu,
 } from "@mantine/core";
 import { IconPlus, IconSearch, IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import { useState, useEffect } from "react";
-import { apiClient } from "@/app/lib/apiClient";
+import { ApiError, apiClient } from "@/app/lib/apiClient";
 import { useForm } from "@mantine/form";
 import EventsTable from "@/app/components/EventsTable";
 import { type Event } from "../components/event-utils";
 import { DateTimePicker, DateTime } from "@/app/components/datetime";
+
+interface EventStatusOption {
+  value: string;
+  label: string;
+}
 
 export default function EventsPage() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -34,6 +39,9 @@ export default function EventsPage() {
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set());
+  const [eventStatuses, setEventStatuses] = useState<EventStatusOption[]>([]);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   const form = useForm({
     initialValues: {
@@ -51,10 +59,24 @@ export default function EventsPage() {
     },
   });
 
+  // Fetch event statuses on mount
+  useEffect(() => {
+    fetchEventStatuses();
+  }, []);
+
   // Fetch events whenever filters change
   useEffect(() => {
     fetchEvents();
   }, [searchQuery, dateFilter]);
+
+  const fetchEventStatuses = async () => {
+    try {
+      const data = await apiClient.get<EventStatusOption[]>("/event-statuses/");
+      setEventStatuses(data);
+    } catch (error) {
+      console.error("Error fetching event statuses:", error);
+    }
+  };
 
   const fetchEvents = async (url?: string) => {
     try {
@@ -75,7 +97,6 @@ export default function EventsPage() {
         next: string | null;
         previous: string | null;
       }>(fetchPath);
-      console.log(data);
 
       setEvents(data.results || []);
       setTotalCount(data.count || 0);
@@ -133,12 +154,47 @@ export default function EventsPage() {
     }
   };
 
-  // TODO: Proper date filtering
-  // const dateFilterOptions = [
-  //   { value: 'all', label: 'All Events' },
-  //   { value: 'upcoming', label: 'Upcoming' },
-  //   { value: 'past', label: 'Past' }
-  // ];
+  const toggleRowSelection = (id: number) => {
+    setSelectedRows((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const handleBulkUpdateStatus = async (eventStatus: string) => {
+    try {
+      await apiClient.post("/events/bulk-update-status/", {
+        ids: Array.from(selectedRows),
+        event_status: eventStatus,
+      });
+      setSelectedRows(new Set());
+      fetchEvents();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        alert("You do not have permission to update events.");
+      } else {
+        alert("Failed to update event statuses. Please try again.");
+      }
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    try {
+      await apiClient.post("/events/bulk-delete/", {
+        ids: Array.from(selectedRows),
+      });
+      setSelectedRows(new Set());
+      setDeleteConfirmOpen(false);
+      fetchEvents();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        alert("You do not have permission to delete events.");
+      } else {
+        alert("Failed to delete events. Please try again.");
+      }
+    }
+  };
 
   return (
     <Container size="xl" py="xl">
@@ -163,19 +219,36 @@ export default function EventsPage() {
                 leftSection={<IconSearch size={16} />}
                 style={{ flex: 1 }}
               />
-              {/*<Select
-                label="Date"
-                placeholder="Filter by date"
-                value={dateFilter}
-                onChange={setDateFilter}
-                data={dateFilterOptions}
-                style={{ minWidth: 200 }}
-              />*/}
             </Group>
-            <Group gap="sm">
+            <Group gap="sm" justify="space-between">
               <Button variant="outline" onClick={handleReset}>
                 Reset
               </Button>
+              <Group gap="xs">
+                <Menu position="bottom-end" shadow="md">
+                  <Menu.Target>
+                    <Button size="xs" variant="light" disabled={selectedRows.size === 0}>
+                      Set Status
+                    </Button>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    {eventStatuses.map((s) => (
+                      <Menu.Item key={s.value} onClick={() => handleBulkUpdateStatus(s.value)}>
+                        {s.label}
+                      </Menu.Item>
+                    ))}
+                  </Menu.Dropdown>
+                </Menu>
+                <Button
+                  size="xs"
+                  variant="light"
+                  color="red"
+                  disabled={selectedRows.size === 0}
+                  onClick={() => setDeleteConfirmOpen(true)}
+                >
+                  Delete
+                </Button>
+              </Group>
             </Group>
           </Stack>
         </Paper>
@@ -184,16 +257,19 @@ export default function EventsPage() {
         <EventsTable
           events={events}
           loading={loading}
-          onRowClick={handleRowClick}
           showTitle={false}
+          isSelectable
+          selectedIds={selectedRows}
+          toggleSelect={toggleRowSelection}
         />
 
-        {/* Pagination and count */}
+        {/* Pagination, result and selected count */}
         <Paper p="sm" withBorder>
-          <Group justify="space-between">
-            <span>
+          <Group justify="space-between" align="center">
+            <Text>
               {totalCount} {totalCount === 1 ? "event" : "events"} found
-            </span>
+            </Text>
+
             <Group gap="xs">
               <ActionIcon
                 variant="filled"
@@ -303,6 +379,29 @@ export default function EventsPage() {
             {/*TODO: Implement participants with issue #24 */}
           </Stack>
         )}
+      </Modal>
+
+      {/* Delete Confirmation Modal */}
+      <Modal
+        opened={deleteConfirmOpen}
+        onClose={() => setDeleteConfirmOpen(false)}
+        title="Confirm Delete"
+        size="sm"
+      >
+        <Stack gap="md">
+          <Text>
+            Are you sure you want to delete {selectedRows.size}{" "}
+            {selectedRows.size === 1 ? "event" : "events"}? This action cannot be undone.
+          </Text>
+          <Group justify="flex-end">
+            <Button variant="outline" onClick={() => setDeleteConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button color="red" onClick={handleBulkDelete}>
+              Delete
+            </Button>
+          </Group>
+        </Stack>
       </Modal>
     </Container>
   );

--- a/Application/app/lib/api.ts
+++ b/Application/app/lib/api.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { apiClient } from "@/app/lib/apiClient";
 
 export interface BackendPaginatedResults<T> {
@@ -18,7 +18,8 @@ export function useBackend<T>(path: string) {
   const [data, setData] = useState<T>();
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>();
-  const [refreshToken, refresh] = useState();
+  const [refreshToken, setRefreshToken] = useState(0);
+  const refresh = useCallback(() => setRefreshToken((n) => n + 1), []);
 
   useEffect(() => {
     let cancelled = false;

--- a/Application/app/lib/apiClient.ts
+++ b/Application/app/lib/apiClient.ts
@@ -1,5 +1,16 @@
 import getCookie from "@/app/utils/cookie";
 
+export class ApiError extends Error {
+  status: number;
+  detail: string;
+
+  constructor(status: number, detail: string) {
+    super(detail);
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(`/api${path}`, {
     ...options,
@@ -11,7 +22,14 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     credentials: "include",
   });
   if (!res.ok) {
-    throw new Error(`API error: ${res.status}`);
+    let detail = `API error: ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body.detail) detail = body.detail;
+    } catch {
+      // response body not JSON, use default message
+    }
+    throw new ApiError(res.status, detail);
   }
   if (res.status === 204) return undefined as T;
   return res.json();

--- a/Application/package-lock.json
+++ b/Application/package-lock.json
@@ -2970,6 +2970,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4322,7 +4323,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -8529,7 +8531,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/Server/dggcrm/events/views.py
+++ b/Server/dggcrm/events/views.py
@@ -44,6 +44,60 @@ class EventViewSet(viewsets.ModelViewSet):
 
         return queryset.filter(get_event_visibility_filter(self.request.user))
 
+    @action(detail=False, methods=["post"], url_path="bulk-update-status")
+    def bulk_update_status(self, request):
+        ids = request.data.get("ids", [])
+        event_status = request.data.get("event_status")
+
+        if not ids or not event_status:
+            return Response(
+                {"detail": "ids and event_status are required."},
+                status=rest_status.HTTP_400_BAD_REQUEST,
+            )
+
+        valid_statuses = [choice[0] for choice in EventStatus.choices]
+        if event_status not in valid_statuses:
+            return Response(
+                {"detail": f"Invalid event_status. Must be one of: {valid_statuses}"},
+                status=rest_status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not request.user.has_perm("events.change_event"):
+            return Response(
+                {"detail": "You do not have permission to update events."},
+                status=rest_status.HTTP_403_FORBIDDEN,
+            )
+
+        queryset = Event.objects.filter(
+            id__in=ids,
+        ).filter(get_event_visibility_filter(request.user))
+
+        updated_count = queryset.update(event_status=event_status)
+        return Response({"updated_count": updated_count})
+
+    @action(detail=False, methods=["post"], url_path="bulk-delete")
+    def bulk_delete(self, request):
+        ids = request.data.get("ids", [])
+
+        if not ids:
+            return Response(
+                {"detail": "ids is required."},
+                status=rest_status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not request.user.has_perm("events.delete_event"):
+            return Response(
+                {"detail": "You do not have permission to delete events."},
+                status=rest_status.HTTP_403_FORBIDDEN,
+            )
+
+        queryset = Event.objects.filter(
+            id__in=ids,
+        ).filter(get_event_visibility_filter(request.user))
+
+        deleted_count, _ = queryset.delete()
+        return Response({"deleted_count": deleted_count})
+
 
 class EventParticipationViewSet(viewsets.ModelViewSet):
     queryset = EventParticipation.objects.select_related("event", "contact").order_by("-created_at")


### PR DESCRIPTION
## Summary
- Click-to-edit inline fields on the event detail page (`/events/[id]`) using Mantine components
- Editable fields: title, description, event status (select), location name, address, start/end dates
- Saves via `PATCH /api/events/{id}/` on blur or Enter, cancels on Escape
- Borderless inputs that match surrounding text for a seamless editing experience
- Fixes `useBackend` hook's `refresh` to properly trigger re-fetches (was a no-op due to `useState()` always being `undefined`)
- Removes redundant "Location Display" read-only row

Fixes #100 
