### PR TITLE
Sync tags from discord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 claude
 CLAUDE.md
 
+# Opencode
+AGENTS.md
+
 # Python
 __pycache__/
 .venv

--- a/Application/app/management/page.tsx
+++ b/Application/app/management/page.tsx
@@ -40,15 +40,15 @@ export default function ManagementConsole() {
     try {
       const data = await apiClient.post<{
         members_fetched: number;
-        contacts_created: number;
-        updated_contacts: number;
-        tags_added: number;
-        tags_removed: number;
+        roles_fetched: number;
+        contacts: { created: number; updated: number };
+        membership_tags: { added: number; removed: number };
+        role_tags: { added: number; removed: number };
       }>("/discord/sync-membership/", {});
 
       setSyncResult({
         type: "success",
-        message: `Retrieved ${data.members_fetched} contacts, created ${data.contacts_created} new contacts, updated ${data.updated_contacts} — ${data.tags_added} tags added, ${data.tags_removed} removed.`,
+        message: `Retrieved ${data.members_fetched} members (${data.roles_fetched} roles), created ${data.contacts.created} new contacts, updated ${data.contacts.updated} — membership tags: ${data.membership_tags.added} added, ${data.membership_tags.removed} removed; role tags: ${data.role_tags.added} added, ${data.role_tags.removed} removed.`,
       });
     } catch {
       setSyncResult({
@@ -102,8 +102,9 @@ export default function ManagementConsole() {
             <Collapse in={discordSectionOpen}>
               <Stack gap="md">
                 <p style={{ color: "gray", fontSize: "0.9rem" }}>
-                  Sync Discord guild membership with contact tags. This fetches all members from the
-                  Discord server and updates the membership tag on matching contacts.
+                  Sync Discord guild membership and roles with contact tags. This fetches all
+                  members and roles from the Discord server, creates tags for Discord roles, and
+                  updates membership/role tags on matching contacts.
                 </p>
 
                 <Button

--- a/Server/dggcrm/discord/client.py
+++ b/Server/dggcrm/discord/client.py
@@ -124,3 +124,82 @@ class DiscordClient:
         Returns just the set of member IDs (for backwards compatibility)
         """
         return {m["id"] for m in self.fetch_all_members()}
+
+    def fetch_all_roles(self) -> list[dict]:
+        """
+        Fetch all guild roles.
+
+        Returns:
+            List of dicts: [{"id": str, "name": str, "color": int}, ...]
+        """
+        url = f"{DISCORD_API_BASE}/guilds/{self.guild_id}/roles"
+
+        try:
+            resp = self.session.get(url, timeout=30)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Network error fetching roles: {e}")
+            return []
+
+        if resp.status_code != 200:
+            logger.error(f"Failed to fetch roles: {resp.status_code} - {resp.text}")
+            return []
+
+        data = resp.json()
+        roles = []
+        for role in data:
+            roles.append(
+                {
+                    "id": role.get("id"),
+                    "name": role.get("name"),
+                    "color": role.get("color", 0),
+                }
+            )
+
+        logger.info(f"Fetched {len(roles)} roles from guild {self.guild_id}")
+        return roles
+
+    def fetch_all_members_with_roles(self) -> list[dict]:
+        """
+        Fetch all guild members with their IDs, display names, and role IDs.
+
+        Returns:
+            List of dicts: [{"id": str, "display_name": str, "role_ids": [str, ...]}, ...]
+        """
+        members: list[dict] = []
+        after: str | None = None
+        page_size = 1000
+        has_more = True
+
+        while has_more:
+            url = f"{DISCORD_API_BASE}/guilds/{self.guild_id}/members?limit={page_size}"
+            if after:
+                url += f"&after={after}"
+
+            try:
+                resp = self.session.get(url, timeout=30)
+            except requests.exceptions.RequestException as e:
+                logger.error(f"Network error fetching members (retries exhausted): {e}")
+                break
+
+            if resp.status_code != 200:
+                logger.error(f"Failed to fetch members: {resp.status_code} - {resp.text}")
+                break
+
+            data = resp.json()
+
+            for member in data:
+                user = member.get("user", {})
+                members.append(
+                    {
+                        "id": user.get("id"),
+                        "display_name": member.get("nick") or user.get("username") or f"Discord {user.get('id')}",
+                        "role_ids": member.get("roles", []),
+                    }
+                )
+
+            has_more = len(data) == page_size
+            if has_more:
+                after = data[-1]["user"]["id"]
+
+        logger.info(f"Fetched {len(members)} members with roles from guild {self.guild_id}")
+        return members

--- a/Server/dggcrm/discord/tests/conftest.py
+++ b/Server/dggcrm/discord/tests/conftest.py
@@ -23,17 +23,27 @@ def mock_discord_members():
 @pytest.fixture
 def mock_discord_client():
     """
-    Creates a mock DiscordClient that can be configured to return specific member IDs.
+    Creates a mock DiscordClient that can be configured to return specific member IDs and roles.
 
     Usage:
         def test_something(mock_discord_client):
-            client = mock_discord_client(member_ids={"123", "456"})
+            client = mock_discord_client(member_ids={"123", "456"}, roles=[...])
             # client.fetch_all_member_ids() will return {"123", "456"}
+            # client.fetch_all_roles() will return [...]
     """
 
-    def _create_client(member_ids: set[str] | None = None):
+    def _create_client(
+        member_ids: set[str] | None = None,
+        members_with_roles: list[dict] | None = None,
+        roles: list[dict] | None = None,
+    ):
         client = MagicMock()
         client.fetch_all_member_ids.return_value = member_ids or set()
+        client.fetch_all_members.return_value = [
+            {"id": mid, "display_name": f"Member {mid}"} for mid in (member_ids or set())
+        ]
+        client.fetch_all_members_with_roles.return_value = members_with_roles or []
+        client.fetch_all_roles.return_value = roles or []
         return client
 
     return _create_client
@@ -51,8 +61,21 @@ def patch_discord_client(mock_discord_client):
                 pass
     """
 
-    def _patch(member_ids: set[str] | None = None, disabled: bool = False):
-        client = None if disabled else mock_discord_client(member_ids)
+    def _patch(
+        member_ids: set[str] | None = None,
+        members_with_roles: list[dict] | None = None,
+        roles: list[dict] | None = None,
+        disabled: bool = False,
+    ):
+        client = (
+            None
+            if disabled
+            else mock_discord_client(
+                member_ids=member_ids,
+                members_with_roles=members_with_roles,
+                roles=roles,
+            )
+        )
         return patch("dggcrm.discord.views.get_discord_client", return_value=client)
 
     return _patch

--- a/Server/dggcrm/discord/tests/test_views.py
+++ b/Server/dggcrm/discord/tests/test_views.py
@@ -96,8 +96,8 @@ class TestSyncMembershipTagsView:
         assert response.status_code == 200
         data = response.json()
         assert data["members_fetched"] == 2
-        assert data["tags_added"] == 2
-        assert data["tags_removed"] == 0
+        assert data["membership_tags"]["added"] == 2
+        assert data["membership_tags"]["removed"] == 0
 
         # Verify tags were created
         tag = Tag.objects.get(name="DGG Discord")
@@ -124,8 +124,8 @@ class TestSyncMembershipTagsView:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["tags_added"] == 0
-        assert data["tags_removed"] == 2
+        assert data["membership_tags"]["added"] == 0
+        assert data["membership_tags"]["removed"] == 2
 
         # Verify Bob and Charlie's tags were removed
         assert TagAssignments.objects.filter(contact=alice, tag=tag).exists()
@@ -155,14 +155,14 @@ class TestSyncMembershipTagsView:
         with patch_discord_client(member_ids=member_ids):
             response1 = authenticated_client.post(self.ENDPOINT)
 
-        assert response1.json()["tags_added"] == 2
+        assert response1.json()["membership_tags"]["added"] == 2
 
         # Second sync - should be idempotent
         with patch_discord_client(member_ids=member_ids):
             response2 = authenticated_client.post(self.ENDPOINT)
 
-        assert response2.json()["tags_added"] == 0
-        assert response2.json()["tags_removed"] == 0
+        assert response2.json()["membership_tags"]["added"] == 0
+        assert response2.json()["membership_tags"]["removed"] == 0
 
     def test_handles_empty_guild(self, authenticated_client, sample_contacts, patch_discord_client):
         """Handles case when no members are returned from Discord."""
@@ -178,7 +178,7 @@ class TestSyncMembershipTagsView:
         assert response.status_code == 200
         data = response.json()
         assert data["members_fetched"] == 0
-        assert data["tags_removed"] == 1
+        assert data["membership_tags"]["removed"] == 1
 
     def test_creates_tag_if_not_exists(self, authenticated_client, sample_contacts, patch_discord_client):
         """Creates the membership tag if it doesn't exist."""
@@ -189,3 +189,123 @@ class TestSyncMembershipTagsView:
 
         assert response.status_code == 200
         assert Tag.objects.filter(name="DGG Discord").exists()
+
+
+@pytest.mark.django_db
+class TestSyncMembershipRolesTags:
+    """Tests for role tag syncing in POST /api/discord/sync-membership/"""
+
+    ENDPOINT = "/api/discord/sync-membership/"
+
+    def test_creates_role_tags_from_discord_roles(self, authenticated_client, sample_contacts, patch_discord_client):
+        """Creates tags from Discord roles."""
+        roles = [
+            {"id": "111", "name": "Moderator", "color": 3447003},
+            {"id": "222", "name": "VIP", "color": 15158332},
+        ]
+        members_with_roles = [
+            {"id": "100000000000000001", "display_name": "Alice Member", "role_ids": ["111"]},
+            {"id": "100000000000000002", "display_name": "Bob Member", "role_ids": ["222"]},
+        ]
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response = authenticated_client.post(self.ENDPOINT)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["roles_fetched"] == 2
+        assert data["role_tags"]["added"] == 2
+
+        assert Tag.objects.filter(name="Moderator").exists()
+        assert Tag.objects.filter(name="VIP").exists()
+
+    def test_assigns_role_tags_to_members(self, authenticated_client, sample_contacts, patch_discord_client):
+        """Assigns role tags to contacts based on their Discord roles."""
+        roles = [{"id": "111", "name": "Moderator", "color": 0}]
+        members_with_roles = [
+            {"id": "100000000000000001", "display_name": "Alice Member", "role_ids": ["111"]},
+            {"id": "100000000000000002", "display_name": "Bob Member", "role_ids": []},
+        ]
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response = authenticated_client.post(self.ENDPOINT)
+
+        assert response.status_code == 200
+
+        alice, bob, _, _ = sample_contacts
+        mod_tag = Tag.objects.get(name="Moderator")
+        assert TagAssignments.objects.filter(contact=alice, tag=mod_tag).exists()
+        assert not TagAssignments.objects.filter(contact=bob, tag=mod_tag).exists()
+
+    def test_updates_role_tag_color(self, authenticated_client, patch_discord_client):
+        """Updates existing role tag color when Discord role color changes."""
+        Tag.objects.create(name="Moderator", color="#000000")
+
+        roles = [{"id": "111", "name": "Moderator", "color": 3447003}]
+        members_with_roles = []
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response = authenticated_client.post(self.ENDPOINT)
+
+        assert response.status_code == 200
+
+        mod_tag = Tag.objects.get(name="Moderator")
+        assert mod_tag.color == "#349dbb"
+
+    def test_removes_role_tags_for_former_members(self, authenticated_client, sample_contacts, patch_discord_client):
+        """Removes role tags from contacts who left the guild."""
+        alice, _, _, _ = sample_contacts
+
+        mod_tag = Tag.objects.create(name="Moderator")
+        TagAssignments.objects.create(contact=alice, tag=mod_tag)
+
+        roles = [{"id": "111", "name": "Moderator", "color": 0}]
+        members_with_roles = []
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response = authenticated_client.post(self.ENDPOINT)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["role_tags"]["removed"] == 1
+        assert not TagAssignments.objects.filter(contact=alice, tag=mod_tag).exists()
+
+    def test_removes_role_tags_when_role_removed_from_member(
+        self, authenticated_client, sample_contacts, patch_discord_client
+    ):
+        """Removes role tags when member no longer has that role."""
+        alice, _, _, _ = sample_contacts
+
+        mod_tag = Tag.objects.create(name="Moderator")
+        TagAssignments.objects.create(contact=alice, tag=mod_tag)
+
+        roles = [{"id": "111", "name": "Moderator", "color": 0}]
+        members_with_roles = [
+            {"id": "100000000000000001", "display_name": "Alice Member", "role_ids": []},
+        ]
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response = authenticated_client.post(self.ENDPOINT)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["role_tags"]["removed"] == 1
+        assert not TagAssignments.objects.filter(contact=alice, tag=mod_tag).exists()
+
+    def test_role_tags_idempotent(self, authenticated_client, sample_contacts, patch_discord_client):
+        """Running sync twice for roles produces the same result."""
+        roles = [{"id": "111", "name": "Moderator", "color": 0}]
+        members_with_roles = [
+            {"id": "100000000000000001", "display_name": "Alice Member", "role_ids": ["111"]},
+        ]
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response1 = authenticated_client.post(self.ENDPOINT)
+
+        assert response1.json()["role_tags"]["added"] == 1
+
+        with patch_discord_client(members_with_roles=members_with_roles, roles=roles):
+            response2 = authenticated_client.post(self.ENDPOINT)
+
+        assert response2.json()["role_tags"]["added"] == 0
+        assert response2.json()["role_tags"]["removed"] == 0

--- a/Server/dggcrm/discord/views.py
+++ b/Server/dggcrm/discord/views.py
@@ -14,11 +14,17 @@ from .client import get_discord_client
 logger = logging.getLogger(__name__)
 
 
+def _int_to_hex(color_int: int) -> str:
+    """Convert Discord role color integer to hex string."""
+    return f"#{color_int:06x}"
+
+
 class SyncMembershipTagsView(APIView):
     """
     POST /api/discord/sync-membership/
 
     Fetches all Discord guild members and syncs membership tags for contacts.
+    Also fetches Discord roles and syncs them as tags with assignments.
     Requires authentication.
     """
 
@@ -29,29 +35,47 @@ class SyncMembershipTagsView(APIView):
         if not client:
             return Response({"error": "Discord bot not configured"}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 
-        # Fetch all Discord members (id + display_name)
-        members = client.fetch_all_members()
+        roles = client.fetch_all_roles()
+        members = client.fetch_all_members_with_roles()
         member_ids = {m["id"] for m in members}
 
-        # Get or create the membership tag
-        tag_name = os.environ.get("DISCORD_MEMBERSHIP_TAG", "DGG Discord")
-        tag, _ = Tag.objects.get_or_create(name=tag_name)
-
-        created = 0
-        updated = 0
-        added = 0
+        role_id_to_tag = {}
 
         with transaction.atomic():
-            # Fetch existing contacts by discord_id
+            # Upsert tags from Discord roles (name + color)
+            for role in roles:
+                discord_role_id = role["id"]
+                role_name = role["name"]
+                role_color = _int_to_hex(role["color"])
+
+                tag, created = Tag.objects.update_or_create(
+                    name=role_name,
+                    defaults={"color": role_color},
+                )
+                role_id_to_tag[discord_role_id] = tag
+
+            # Get or create the membership tag (e.g., "DGG Discord")
+            membership_tag_name = os.environ.get("DISCORD_MEMBERSHIP_TAG", "DGG Discord")
+            membership_tag, _ = Tag.objects.get_or_create(name=membership_tag_name)
+
             existing_contacts = {c.discord_id: c for c in Contact.objects.exclude(discord_id="")}
 
+            created = 0
+            updated = 0
+            added = 0
+            role_tags_added = 0
+
             tag_assignments_to_add = []
+            existing_tag_assignment_keys = set(TagAssignments.objects.values_list("contact_id", "tag_id"))
+
+            # Track which role assignments should exist after sync
+            expected_role_assignments: set[tuple[int, int]] = set()
 
             for member in members:
                 discord_id = member["id"]
                 display_name = member["display_name"]
+                member_role_ids = set(member.get("role_ids", []))
 
-                # Get or create the Contact
                 contact = existing_contacts.get(discord_id)
                 if not contact:
                     contact = Contact(discord_id=discord_id, full_name=display_name)
@@ -59,33 +83,63 @@ class SyncMembershipTagsView(APIView):
                     existing_contacts[discord_id] = contact
                     created += 1
                 else:
-                    # Update full_name if changed
                     if contact.full_name != display_name:
                         contact.full_name = display_name
                         contact.save(update_fields=["full_name"])
                         updated += 1
 
-                # Check if TagAssignments already exist
-                has_tag = TagAssignments.objects.filter(tag=tag, contact=contact).exists()
-                if not has_tag:
-                    tag_assignments_to_add.append(TagAssignments(contact=contact, tag=tag))
+                # Add membership tag if missing
+                has_membership_tag = (contact.id, membership_tag.id) in existing_tag_assignment_keys
+                if not has_membership_tag:
+                    tag_assignments_to_add.append(TagAssignments(contact=contact, tag=membership_tag))
                     added += 1
 
-            # Bulk create tag assignments safely
+                # Add role tags and track expected assignments
+                for role_id in member_role_ids:
+                    tag = role_id_to_tag.get(role_id)
+                    if tag:
+                        expected_role_assignments.add((contact.id, tag.id))
+                        assignment_key = (contact.id, tag.id)
+                        if assignment_key not in existing_tag_assignment_keys:
+                            tag_assignments_to_add.append(TagAssignments(contact=contact, tag=tag))
+                            role_tags_added += 1
+
             TagAssignments.objects.bulk_create(tag_assignments_to_add, ignore_conflicts=True)
 
-            # Remove tag assignments for contacts no longer in the guild
+            # Remove membership tags for contacts who left the guild
             contacts_to_remove = Contact.objects.exclude(discord_id__in=member_ids)
-            removed, _ = TagAssignments.objects.filter(tag=tag, contact__in=contacts_to_remove).delete()
+            removed, _ = TagAssignments.objects.filter(tag=membership_tag, contact__in=contacts_to_remove).delete()
 
-        logger.info(f"Sync complete: created={created}, updated={updated}, tags_added={added}, tags_removed={removed}")
+            # Remove role tags for members who no longer have those roles
+            existing_role_tags = set(role_id_to_tag.values())
+            role_tags_removed = 0
+            if existing_role_tags:
+                for assignment in TagAssignments.objects.filter(tag__in=existing_role_tags):
+                    if (assignment.contact_id, assignment.tag_id) not in expected_role_assignments:
+                        assignment.delete()
+                        role_tags_removed += 1
+
+        logger.info(
+            f"Sync complete: created={created}, updated={updated}, "
+            f"tags_added={added}, role_tags_added={role_tags_added}, "
+            f"tags_removed={removed}, role_tags_removed={role_tags_removed}"
+        )
 
         return Response(
             {
                 "members_fetched": len(member_ids),
-                "contacts_created": created,
-                "updated_contacts": updated,
-                "tags_added": added,
-                "tags_removed": removed,
+                "roles_fetched": len(roles),
+                "contacts": {
+                    "created": created,
+                    "updated": updated,
+                },
+                "membership_tags": {
+                    "added": added,
+                    "removed": removed,
+                },
+                "role_tags": {
+                    "added": role_tags_added,
+                    "removed": role_tags_removed,
+                },
             }
         )


### PR DESCRIPTION
## Summary

Extends the Discord sync feature to also sync Discord server roles as contact tags. Previously, the sync only added a "DGG Discord" membership tag to members. Now it also:

- Fetches all Discord server roles and creates/updates tags with role names and colors
- Assigns role-based tags to contacts based on their Discord roles
- Removes role tags when members lose roles or leave the server

## Changes

### Backend (Server/dggcrm/discord/)
- client.py: Added fetch_all_roles() and fetch_all_members_with_roles() methods to Discord API client
- views.py: Extended SyncMembershipTagsView to sync Discord roles as tags with assignments

### Frontend (Application/app/management/page.tsx)
- Updated UI to display role sync metrics in the success message

### Tests (Server/dggcrm/discord/tests/)
- Updated mock to support new client methods
- Added 6 new tests for role tag syncing behavior

## API Response

The response now includes nested structure:
{
  "members_fetched": 100,
  "roles_fetched": 15,
  "contacts": { "created": 5, "updated": 10 },
  "membership_tags": { "added": 5, "removed": 0 },
  "role_tags": { "added": 50, "removed": 3 }
}

## Notes

- Role name collisions: If two Discord roles have the same name but different colors, the most recent sync will update the tag color
- Idempotent: Running the sync multiple times produces the same result
