### PR TITLE
Implement searchable tag for contacts page

### DIFF
--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -8,7 +8,6 @@ import {
   Paper,
   Text,
   TextInput,
-  Select,
   Stack,
   Modal,
   MultiSelect,
@@ -28,6 +27,7 @@ import { useRouter } from "next/navigation";
 import { apiClient } from "@/app/lib/apiClient";
 import { useForm } from "@mantine/form";
 import { TicketBulkCreateModal } from "@/app/components/tickets/TicketBulkCreateModal";
+import { SearchSelect, type SearchSelectOption } from "@/app/components/SearchSelect";
 import ContactTable, {
   type Contact,
   type Group as ContactGroup,
@@ -42,7 +42,7 @@ export default function ContactsPage() {
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedGroup, setSelectedGroup] = useState<string | null>("all");
-  const [selectedTag, setSelectedTag] = useState<string | null>("all");
+  const [selectedTag, setSelectedTag] = useState<SearchSelectOption<Tag> | null>(null);
   const [startDate, setStartDate] = useState<string | null>("");
   const [endDate, setEndDate] = useState<string | null>("");
   const [minEvents, setMinEvents] = useState<number | string>();
@@ -124,7 +124,7 @@ export default function ContactsPage() {
         if (startDate) params.append("start_date", startDate);
         if (endDate) params.append("end_date", endDate);
 
-        if (selectedTag && selectedTag !== "all") params.append("tag", selectedTag);
+        if (selectedTag) params.append("tag", selectedTag.id.toString());
         fetchUrl = `/contacts/?${params}`;
       }
 
@@ -152,7 +152,7 @@ export default function ContactsPage() {
   const handleReset = () => {
     setSearchQuery("");
     setSelectedGroup("all");
-    setSelectedTag("all");
+    setSelectedTag(null);
     setMaxEvents("");
     setMinEvents("");
     setMaxTickets("");
@@ -223,11 +223,6 @@ export default function ContactsPage() {
     console.log("Upload CSV clicked");
   };
 
-  const tagOptions = [
-    { value: "all", label: "Any" },
-    ...tags.map((t) => ({ value: t.id.toString(), label: t.name })),
-  ];
-
   return (
     <Container size="xl" py="xl">
       <Stack gap="md">
@@ -261,13 +256,18 @@ export default function ContactsPage() {
                 style={{ flex: 1 }}
               />
 
-              <Select
+              <SearchSelect<Tag>
+                endpoint="/tags/"
                 label="Tag"
-                placeholder="Select tag"
+                placeholder="Search tags..."
                 value={selectedTag}
                 onChange={setSelectedTag}
-                data={tagOptions}
-                style={{ minWidth: 200 }}
+                clearable
+                mapResult={(tag) => ({
+                  id: tag.id,
+                  label: tag.name,
+                  raw: tag,
+                })}
               />
             </Group>
             <Group>

--- a/Server/dggcrm/contacts/views.py
+++ b/Server/dggcrm/contacts/views.py
@@ -139,6 +139,8 @@ class TagViewSet(viewsets.ModelViewSet):
         IsAuthenticated,
         DjangoModelPermissions,
     ]
+    filter_backends = [filters.SearchFilter]
+    search_fields = ["name"]
 
 
 class TagAssignmentViewSet(viewsets.ModelViewSet):

--- a/Server/dggcrm/discord/tests/conftest.py
+++ b/Server/dggcrm/discord/tests/conftest.py
@@ -42,6 +42,11 @@ def mock_discord_client():
         client.fetch_all_members.return_value = [
             {"id": mid, "display_name": f"Member {mid}"} for mid in (member_ids or set())
         ]
+
+        # If members_with_roles not provided, derive from member_ids
+        if members_with_roles is None and member_ids:
+            members_with_roles = [{"id": mid, "display_name": f"Member {mid}", "role_ids": []} for mid in member_ids]
+
         client.fetch_all_members_with_roles.return_value = members_with_roles or []
         client.fetch_all_roles.return_value = roles or []
         return client

--- a/Server/dggcrm/discord/tests/test_views.py
+++ b/Server/dggcrm/discord/tests/test_views.py
@@ -250,7 +250,7 @@ class TestSyncMembershipRolesTags:
         assert response.status_code == 200
 
         mod_tag = Tag.objects.get(name="Moderator")
-        assert mod_tag.color == "#349dbb"
+        assert mod_tag.color == "#3498db"
 
     def test_removes_role_tags_for_former_members(self, authenticated_client, sample_contacts, patch_discord_client):
         """Removes role tags from contacts who left the guild."""

--- a/Server/dggcrm/tickets/views.py
+++ b/Server/dggcrm/tickets/views.py
@@ -357,6 +357,12 @@ class TicketTypeViewSet(viewsets.ViewSet):
 
     def list(self, request):
         types = [{"value": t.value, "label": t.label} for t in TicketType]
+        search = request.query_params.get("search", "").lower()
+        if search:
+            types = [t for t in types if search in t["label"].lower()]
+        page_size = request.query_params.get("page_size")
+        if page_size:
+            types = types[: int(page_size)]
         return Response(types)
 
 


### PR DESCRIPTION
Implements searching of tags:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/350e9ec0-143d-43cf-9416-160846a1ad90" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8eb64a7a-ced7-43c9-abf8-d2350d662895" />

This only supports selecting one tag, but we could update SearchSelect to support multi-select later on. This PR just makes the one tag searchable.