### PR TITLE
Fixing pagination buttons

### DIFF
--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -135,7 +135,7 @@ export default function ContactsPage() {
         count: number;
         next: string | null;
         previous: string | null;
-      }>(fetchUrl?.replace(/^\/api/, "") || `/contacts/`);
+      }>(fetchUrl || `/contacts/`);
 
       console.log("Fetched contacts data:", data);
       setContacts(data.results);

--- a/Application/app/lib/apiClient.ts
+++ b/Application/app/lib/apiClient.ts
@@ -1,7 +1,9 @@
 import getCookie from "@/app/utils/cookie";
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(`/api${path}`, {
+  const isFullUrl = path.startsWith("http://") || path.startsWith("https://");
+  const url = isFullUrl ? path : `/api${path}`;
+  const res = await fetch(url, {
     ...options,
     headers: {
       "Content-Type": "application/json",

--- a/Application/app/tickets/page.tsx
+++ b/Application/app/tickets/page.tsx
@@ -96,7 +96,7 @@ export default function TicketPage() {
   ) => {
     try {
       setLoading(true);
-      let fetchPath = url?.replace(/^\/api/, "") || "/tickets";
+      let fetchPath = url || "/tickets";
 
       // Add filters if not using pagination URL
       if (!url) {


### PR DESCRIPTION
Noticed that the pagination buttons seem to have been broken at some point.

<img width="2074" height="183" alt="image" src="https://github.com/user-attachments/assets/5151b673-2515-4ee4-9ba2-fefb6daa0e5c" />

Mainly they format as `GET
https://house.digitalgroundgame.org/apihttp:/house.digitalgroundgame.org/api/contacts?page=2`, which is definetly wrong. The issue is that our api code assumes we are always passing a relative path. However, django pagination uses full uris:

```json
{
    "count": 128,
    "next": "http://localhost:3030/api/contacts/?page=4",
    "previous": "http://localhost:3030/api/contacts/?page=2"
    ...
}
```

This PR updates the code to support full URIs.