### PR TITLE
Libdough/issue 103

### DIFF
--- a/Application/app/components/event-utils.ts
+++ b/Application/app/components/event-utils.ts
@@ -56,3 +56,11 @@ export const getEventParticipationStatusColor = (status: string) => {
       return "DimGray";
   }
 };
+
+export interface UsersInEvent {
+  id: number;
+  user: number;
+  user_username: string;
+  event: number;
+  joined_at: string;
+}

--- a/Application/app/components/pagination/PaginatedTable.tsx
+++ b/Application/app/components/pagination/PaginatedTable.tsx
@@ -134,11 +134,13 @@ export default function PaginatedTable<T>(props: PaginatedTableProps<T>) {
 
         <Table.Tbody>
           {data.length === 0 && noDataText ? (
-            <Table.Tr>
-              <Text c="dimmed">{noDataText}</Text>
+            <Table.Tr key="no-data">
+              <Table.Td colSpan={columns.length}>
+                <Text c="dimmed">{noDataText}</Text>
+              </Table.Td>
             </Table.Tr>
           ) : (
-            data.map((ele) => {
+            data.map((ele, index) => {
               const id = keyFn?.(ele);
 
               return (
@@ -149,7 +151,7 @@ export default function PaginatedTable<T>(props: PaginatedTableProps<T>) {
                       : undefined
                   }
                   style={{ cursor: "pointer" }}
-                  key={id}
+                  key={id ?? `row-${index}`}
                   onClick={() => onRowClick?.(ele)}
                 >
                   {useCheckboxes && id !== undefined && (

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -5,10 +5,12 @@ import PaginationBar, {
   incrementPageSearchParam,
 } from "@/app/components/pagination/PaginationBar";
 import { formatContactInfo } from "@/app/components/contact-utils";
+import { User } from "@/app/components/provider/types";
 import {
   Event,
   EventParticipation,
   getEventParticipationStatusColor,
+  UsersInEvent,
 } from "@/app/components/event-utils";
 import { BackendPaginatedResults, useBackend, useBackendMutation } from "@/app/lib/api";
 import {
@@ -32,8 +34,10 @@ import {
   Select,
   Combobox,
   useCombobox,
+  Tabs,
 } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
+import { notifications } from "@mantine/notifications";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
@@ -69,7 +73,18 @@ function EventViewMain({ event }: { event: Event }) {
             <Text>{event.description}</Text>
           </Stack>
         </Paper>
-        <EventViewContactTable event={event} />
+        <Tabs defaultValue="participants" mt="md">
+          <Tabs.List>
+            <Tabs.Tab value="participants">Participants</Tabs.Tab>
+            <Tabs.Tab value="users">Users</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="participants">
+            <EventViewContactTable event={event} />
+          </Tabs.Panel>
+          <Tabs.Panel value="users">
+            <EventViewUsersTable event={event} />
+          </Tabs.Panel>
+        </Tabs>
       </GridCol>
       <EventViewMetadata event={event} />
     </Grid>
@@ -151,7 +166,7 @@ function AddParticipantModal({
   const contactsSearch = useBackend<BackendPaginatedResults<Contact>>(
     `/api/contacts/?${apiParams}`
   );
-  const { mutate, loading, error } = useBackendMutation(`/api/participants`, {
+  const { mutate, loading, error } = useBackendMutation(`/api/participants/`, {
     method: "POST",
     credentials: "include",
     headers: {
@@ -268,10 +283,9 @@ function AddParticipantModal({
 
 function EventViewContactTable({ event }: { event: Event }) {
   const currentParams = useSearchParams();
-  const [searchQuery, setSearchQuery] = useState<string>();
+  const [searchQuery, setSearchQuery] = useState<string>("");
   const [statusArray, setStatusArray] = useState<string[]>();
   const [opened, { open, close }] = useDisclosure(false);
-  const [refreshIndex, setRefreshIndex] = useState(0);
 
   const pageNum = currentParams.get("page");
   const apiParams = new URLSearchParams();
@@ -286,13 +300,14 @@ function EventViewContactTable({ event }: { event: Event }) {
 
   apiParams.append("event", event.id.toString());
 
-  const { data, loading, error } = useBackend<BackendPaginatedResults<EventParticipation>>(
-    `/api/participants/?${apiParams}`
-  );
+  const {
+    data,
+    loading,
+    error,
+    refresh: refetch,
+  } = useBackend<BackendPaginatedResults<EventParticipation>>(`/api/participants/?${apiParams}`);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const router = useRouter();
-
-  const refresh = () => setRefreshIndex((prev) => prev + 1);
 
   const updateParam = (key: string, value?: string) => {
     const params = new URLSearchParams(currentParams.toString());
@@ -311,7 +326,7 @@ function EventViewContactTable({ event }: { event: Event }) {
           selected={selectedData}
           opened={opened}
           close={close}
-          refresh={refresh}
+          refresh={refetch}
         />
       )}
       <Paper p="md" mt="sm" withBorder style={{ position: "relative" }}>
@@ -384,5 +399,291 @@ function EventViewContactTable({ event }: { event: Event }) {
         </Stack>
       </Paper>
     </>
+  );
+}
+
+function EventViewUsersTable({ event }: { event: Event }) {
+  const currentParams = useSearchParams();
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [addModalOpened, { open: openAddModal, close: closeAddModal }] = useDisclosure(false);
+
+  const pageNum = currentParams.get("page");
+  const apiParams = new URLSearchParams();
+
+  if (pageNum) apiParams.append("page", pageNum);
+  if (searchQuery) apiParams.append("search", searchQuery);
+
+  apiParams.append("event", event.id.toString());
+
+  const {
+    data,
+    loading,
+    refresh: refetch,
+  } = useBackend<BackendPaginatedResults<UsersInEvent>>(`/api/assignments/?${apiParams}`);
+  const router = useRouter();
+
+  const updateParam = (key: string, value?: string) => {
+    const params = new URLSearchParams(currentParams.toString());
+
+    if (!value || value === "all") params.delete(key);
+    else params.set(key, value);
+
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
+
+  const handleDelete = async (userId: number) => {
+    setDeletingId(userId);
+    try {
+      const response = await fetch(`/api/assignments/${userId}/`, {
+        method: "DELETE",
+        credentials: "include",
+        headers: {
+          "X-CSRFToken": getCookie("csrftoken") ?? "",
+        },
+      });
+      if (response.ok) {
+        refetch();
+      } else if (response.status === 403) {
+        notifications.show({
+          title: "Permission Denied",
+          message: "You do not have permission to remove this user from the event.",
+          color: "red",
+        });
+      } else {
+        notifications.show({
+          title: "Error",
+          message: "Failed to remove user. Please try again.",
+          color: "red",
+        });
+      }
+    } catch {
+      notifications.show({
+        title: "Error",
+        message: "Failed to remove user. Please try again.",
+        color: "red",
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <>
+      {addModalOpened && (
+        <AddUserModal
+          event={event}
+          opened={addModalOpened}
+          close={closeAddModal}
+          refresh={refetch}
+          currentUsers={data?.results ?? []}
+        />
+      )}
+      <Paper p="md" mt="sm" withBorder style={{ position: "relative" }}>
+        <Stack>
+          <Group grow align="flex-end">
+            <TextInput
+              label="Search"
+              placeholder="Search by username..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              leftSection={<IconSearch size={16} />}
+            />
+            <Button onClick={openAddModal}>Add User</Button>
+          </Group>
+          {data && (
+            <PaginatedTable
+              title="Users"
+              showTitle={true}
+              data={data.results}
+              columns={["Username", "Joined At"]}
+              selected={new Set()}
+              transforms={[
+                (user: UsersInEvent) => (
+                  <Table.Td key={user.user_username}>{user.user_username}</Table.Td>
+                ),
+                (user: UsersInEvent) => (
+                  <Table.Td key={user.joined_at}>
+                    {new Date(user.joined_at).toLocaleString()}
+                  </Table.Td>
+                ),
+                (user: UsersInEvent) => (
+                  <Table.Td key={user.id}>
+                    <Button
+                      color="red"
+                      size="xs"
+                      loading={deletingId === user.id}
+                      onClick={() => handleDelete(user.id)}
+                    >
+                      Remove
+                    </Button>
+                  </Table.Td>
+                ),
+              ]}
+              loading={loading}
+              keyFn={(user: UsersInEvent) => user.id}
+            />
+          )}
+          {data && (
+            <PaginationBar
+              entityName="User(s)"
+              totalCount={data?.count}
+              previousUrl={data?.previous}
+              nextUrl={data.next}
+              handleNext={() =>
+                data.next && updateParam("page", incrementPageSearchParam(currentParams))
+              }
+              handlePrevious={() =>
+                data.previous && updateParam("page", decrementPageSearchParam(currentParams))
+              }
+            />
+          )}
+        </Stack>
+      </Paper>
+    </>
+  );
+}
+
+function AddUserModal({
+  event,
+  opened,
+  close,
+  refresh,
+  currentUsers,
+}: {
+  event: Event;
+  opened: boolean;
+  close: () => void;
+  refresh: () => void;
+  currentUsers: UsersInEvent[];
+}) {
+  const [userSearchQuery, setUserSearchQuery] = useState<string>("");
+  const [selectedUsers, setSelectedUsers] = useState<Set<User>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  const apiParams = new URLSearchParams();
+  if (userSearchQuery) apiParams.append("search", userSearchQuery);
+
+  const usersSearch = useBackend<BackendPaginatedResults<User>>(`/api/users/?${apiParams}`);
+  const { mutate: addMutate } = useBackendMutation(`/api/assignments/`, {
+    method: "POST",
+  });
+
+  const currentUserIds = new Set(currentUsers.map((u) => u.user));
+
+  const availableUsers = usersSearch.data?.results.filter((u) => !currentUserIds.has(u.id)) ?? [];
+  const combobox = useCombobox();
+
+  const removeUser = (u: User) => {
+    setSelectedUsers((prev) => {
+      const next = new Set(prev);
+      next.delete(u);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await Promise.all(
+        Array.from(selectedUsers).map((u) =>
+          addMutate({
+            event: event.id,
+            user: u.id,
+          })
+        )
+      );
+      setSelectedUsers(new Set());
+      close();
+      refresh();
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      if (errorMessage.includes("403")) {
+        notifications.show({
+          title: "Permission Denied",
+          message: "You do not have permission to add users to this event.",
+          color: "red",
+        });
+      } else {
+        notifications.show({
+          title: "Error",
+          message: "Failed to add users. Please try again.",
+          color: "red",
+        });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={close} title="Add User">
+      <LoadingOverlay visible={submitting} />
+      <Stack>
+        <Combobox
+          store={combobox}
+          onOptionSubmit={(value) => {
+            const user = availableUsers.find((u) => u.id.toString() === value);
+            if (!user) return;
+
+            setSelectedUsers((prev) => {
+              const next = new Set(prev);
+              next.add(user);
+              return next;
+            });
+            setUserSearchQuery("");
+            combobox.closeDropdown();
+          }}
+        >
+          <Combobox.Target>
+            <TextInput
+              label="User"
+              placeholder="Search users..."
+              value={userSearchQuery}
+              onChange={(event) => {
+                setUserSearchQuery(event.currentTarget.value);
+                combobox.openDropdown();
+              }}
+              onFocus={() => combobox.openDropdown()}
+              onClick={() => combobox.openDropdown()}
+              onBlur={() => combobox.closeDropdown()}
+              rightSection={usersSearch.loading ? <LoadingOverlay visible /> : null}
+            />
+          </Combobox.Target>
+
+          <Combobox.Dropdown hidden={availableUsers.length === 0}>
+            <Combobox.Options>
+              {availableUsers.map((user) => (
+                <Combobox.Option key={user.id} value={user.id.toString()}>
+                  {user.username}
+                </Combobox.Option>
+              ))}
+
+              {availableUsers.length === 0 && <Combobox.Empty>No users found</Combobox.Empty>}
+            </Combobox.Options>
+          </Combobox.Dropdown>
+        </Combobox>
+        <PaginatedTable
+          columns={["Username", "Email"]}
+          data={Array.from(selectedUsers)}
+          transforms={[
+            (u: User) => <Table.Td key="username">{u.username}</Table.Td>,
+            (u: User) => <Table.Td key="email">{u.email}</Table.Td>,
+            (u: User) => (
+              <Table.Td key="actions">
+                <Button color="red" onClick={() => removeUser(u)}>
+                  Remove
+                </Button>
+              </Table.Td>
+            ),
+          ]}
+          loading={false}
+          noDataText="Select a user to proceed"
+        />
+        <Button onClick={handleSubmit} disabled={selectedUsers.size === 0}>
+          Submit
+        </Button>
+      </Stack>
+    </Modal>
   );
 }

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -343,7 +343,7 @@ function EventViewContactTable({ event }: { event: Event }) {
               title="Participants"
               showTitle={true}
               data={data.results}
-              onRowClick={(contact: EventParticipation) => router.push(`/contacts/${contact.id}`)}
+              onRowClick={(ep: EventParticipation) => router.push(`/contacts/${ep.contact.id}`)}
               columns={["Name", "Contact", "Status"]}
               transforms={[
                 (ep) => <Table.Td key={ep.contact.full_name}>{ep.contact.full_name}</Table.Td>,

--- a/Application/app/lib/api.ts
+++ b/Application/app/lib/api.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiClient } from "@/app/lib/apiClient";
+import getCookie from "@/app/utils/cookie";
 
 export interface BackendPaginatedResults<T> {
   count: number;
@@ -78,8 +79,10 @@ export function useBackendMutation<TResponse, TBody = unknown>(
         body: body ? JSON.stringify(body) : options?.body,
         headers: {
           "Content-Type": "application/json",
+          "X-CSRFToken": getCookie("csrftoken") || "",
           ...options?.headers,
         },
+        credentials: "include",
       });
 
       if (!res.ok) {

--- a/Server/dggcrm/events/views.py
+++ b/Server/dggcrm/events/views.py
@@ -95,7 +95,7 @@ class EventParticipationViewSet(viewsets.ModelViewSet):
         if contact_id:
             queryset = queryset.filter(contact_id=contact_id)
 
-        return queryset.filter(get_participation_visibility_filter(self.request.user))
+        return queryset.filter(get_participation_visibility_filter(self.request.user)).distinct()
 
     # TODO: Limit this API to organizer role or above
     @action(detail=False, methods=["get"])
@@ -188,7 +188,7 @@ class UsersInEventViewSet(viewsets.ModelViewSet):
     queryset = UsersInEvent.objects.select_related(
         "user",
         "event",
-    )
+    ).distinct()
     serializer_class = UsersInEventSerializer
     permission_classes = [IsAuthenticated, DjangoModelPermissions, EventMembershipObjectPermission]
 


### PR DESCRIPTION
Resolves #103 

Updates the events page to include a users in event tab. Adding users to an event will allow non-super users to access the associated contacts/tickets associated with this event (permission model).

We can use the users in event tab to update the linked users:
<img width="2049" height="1399" alt="image" src="https://github.com/user-attachments/assets/07685163-8b67-4ff2-be0c-a83cddb125ff" />

I also added a modal to add these users:
<img width="1075" height="651" alt="image" src="https://github.com/user-attachments/assets/88e72e67-1664-4ad3-9d86-e0dc4394c25e" />

This modal works very similarly to the existing add participant modal. I also fixed a few issues I discovered in the process of implementing this page. (including missing csrf tokens + trailing slashes).