### PR TITLE
Fix invalid migration sequence for event type on new server setup

### DIFF
--- a/Server/dggcrm/events/migrations/0002_add_event_type.py
+++ b/Server/dggcrm/events/migrations/0002_add_event_type.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.AlterField(
             model_name="event",
             name="event_type",
             field=models.CharField(


### PR DESCRIPTION
`0002_add_event_type.py` was using `AddField` to add `event_type`, but that column already exists from `0001_initial.py`. This caused migrations to fail on any database that had already run 0001, with the error:

```
ERROR: column "event_type" of relation "events" already exists
```
Changed `AddField` to `AlterField` so the migration correctly updates the existing column's choices and default value from the typo'd "genric" to "generic" instead of trying to create a duplicate column.

Related: #156 & #158 (and #157, but I think this is necessary since there is an error running migrations normally.)