### PR TITLE
Fix healthcheck endpoints for server and frontend

### DIFF
--- a/Application/app/health/route.ts
+++ b/Application/app/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return new Response("ok", { status: 200 });
+}

--- a/Application/proxy.ts
+++ b/Application/proxy.ts
@@ -9,6 +9,7 @@ export function proxy(request: NextRequest) {
   const isLoginPage = pathname === "/login";
   const isPublic =
     pathname === "/login" ||
+    pathname === "/health" ||
     pathname.startsWith("/_next") ||
     pathname.startsWith("/favicon") ||
     pathname.startsWith("/accounts") ||

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -35,9 +35,9 @@ services:
     - "traefik.http.services.https-<uuid>-nginx.loadbalancer.server.port=80"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/health"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
       start_period: 10s
     networks:
       - coolify
@@ -59,9 +59,9 @@ services:
       - "3030"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:3030/health"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
       start_period: 15s
 
   server: &server
@@ -104,9 +104,9 @@ services:
     command: /start
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/api/health/?format=text"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
       start_period: 10s
 
 
@@ -129,9 +129,9 @@ services:
       - "5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 5
 
 volumes:
   dggcrm_production_postgres_data:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -58,7 +58,7 @@ services:
     expose:
       - "3030"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:3030/"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3030/health"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -103,7 +103,7 @@ services:
       - "8080"
     command: /start
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/api/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/api/health/?format=text"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
Both the Django server and Next.js frontend healthchecks were returning false positives, passing even when the services were effectively unreachable.

### Django

The health check defined in the docker config was hitting `http://localhost:8080/api/health`, but Django defaults to redirecting a non-trailing slash to a trailing slash ie `http://localhost:8080/api/health` → `http://localhost:8080/api/health/`, so the health check was returning:

```http
< HTTP/1.1 301 Moved Permanently
< Server: gunicorn
< Date: Sat, 11 Apr 2026 23:46:25 GMT
< Connection: close
< Content-Type: text/html; charset=utf-8
< Location: /api/health/
< Content-Length: 0
< Vary: origin, Cookie
< X-Content-Type-Options: nosniff
< Referrer-Policy: same-origin
< Cross-Origin-Opener-Policy: same-origin
```

Notice it's a `301` redirect with a content length of 0. I can also confirm this is what is actually happening because the docker logs for it's health checks shows that the health check is returning content length of 0:

```json
{
  "Start": "2026-04-11T23:46:58.40026501Z",
  "End": "2026-04-11T23:46:58.487068133Z",
  "ExitCode": 0,
  "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed
 0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n"
}
```

But this is still being evaluated as a successful response. So the fix is to change to the trailing slash version of the URL, and while I'm at it I'm changing to use the `txt` version of the response so that it's not returning a giant blob of HTML on every request. 

### Next

Essentially the exact same thing was happening with the frontend request, but this is caused by the `proxy.ts` redirecting all requests to `/login`, again giving a successful response (this one would probably actually still fail on crash, since it's the actual application doing the redirect, but still nice to have it behave in an expected way).


I also changed the interval from 5 seconds → 10 seconds, as 5 seconds with a 5 second timeout is a bit overkill and hypothetically only makes things worse on a struggling server. And reduced the retries to 5, so it'll be the same 50 second period, but with 1/2 of the requests.

ps It's still possible there are other issues with the notification being sent, I don't have an easy way to test end-to-end with coolify without the server actually crashing.