### PR TITLE
Add multi-select tag filter for contacts

### DIFF
--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   Paper,
   TextInput,
-  Select,
   Stack,
   Modal,
   MultiSelect,
@@ -24,7 +23,7 @@ export default function PeoplePage() {
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedGroup, setSelectedGroup] = useState<string | null>('all');
-  const [selectedTag, setSelectedTag] = useState<string | null>('all');
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
   const [nextUrl, setNextUrl] = useState<string | null>(null);
   const [previousUrl, setPreviousUrl] = useState<string | null>(null);
@@ -58,7 +57,7 @@ export default function PeoplePage() {
   // Fetch people whenever filters change (reset to first page)
   useEffect(() => {
     fetchPeople();
-  }, [searchQuery, selectedGroup, selectedTag]);
+  }, [searchQuery, selectedGroup, selectedTagIds]);
 
   const fetchGroupsAndTags = async () => {
     try {
@@ -90,7 +89,9 @@ export default function PeoplePage() {
       if (!fetchUrl) {
         const params = new URLSearchParams();
         if (searchQuery) params.append('q', searchQuery);
-        if (selectedTag && selectedTag !== 'all') params.append('tag', selectedTag);
+        for (const selectedTagId of selectedTagIds) {
+          params.append('tag', selectedTagId);
+        }
         fetchUrl = `/api/contacts/?${params}`;
       }
 
@@ -114,7 +115,7 @@ export default function PeoplePage() {
   const handleReset = () => {
     setSearchQuery('');
     setSelectedGroup('all');
-    setSelectedTag('all');
+    setSelectedTagIds([]);
   };
 
   const handleRowClick = (person: Person) => {
@@ -170,7 +171,6 @@ export default function PeoplePage() {
 
 
   const tagOptions = [
-    { value: 'all', label: 'Any' },
     ...tags.map(t => ({ value: t.id.toString(), label: t.name }))
   ];
 
@@ -210,13 +210,15 @@ export default function PeoplePage() {
                 style={{ flex: 1 }}
               />
 
-              <Select
+              <MultiSelect
                 label="Tag"
-                placeholder="Select tag"
-                value={selectedTag}
-                onChange={setSelectedTag}
+                placeholder="Select tags"
+                value={selectedTagIds}
+                onChange={setSelectedTagIds}
                 data={tagOptions}
-                style={{ minWidth: 200 }}
+                searchable
+                clearable
+                style={{ minWidth: 240 }}
               />
             </Group>
             <Group gap="sm">

--- a/Server/dggcrm/contacts/tests.py
+++ b/Server/dggcrm/contacts/tests.py
@@ -1,0 +1,117 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from .models import Contact, Tag, TagAssignments
+
+
+class ContactTagFilterTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        self.alpha = Tag.objects.create(name="alpha", color="#111111")
+        self.beta = Tag.objects.create(name="beta", color="#222222")
+
+        self.contact_alpha = Contact.objects.create(
+            full_name="Alpha Only",
+            discord_id="alpha-only",
+        )
+        self.contact_beta = Contact.objects.create(
+            full_name="Beta Only",
+            discord_id="beta-only",
+        )
+        self.contact_both = Contact.objects.create(
+            full_name="Both Tags",
+            discord_id="both-tags",
+        )
+        self.contact_none = Contact.objects.create(
+            full_name="No Tags",
+            discord_id="no-tags",
+        )
+
+        TagAssignments.objects.create(contact=self.contact_alpha, tag=self.alpha)
+        TagAssignments.objects.create(contact=self.contact_beta, tag=self.beta)
+        TagAssignments.objects.create(contact=self.contact_both, tag=self.alpha)
+        TagAssignments.objects.create(contact=self.contact_both, tag=self.beta)
+
+    def get_results(self, response):
+        self.assertEqual(response.status_code, 200)
+        return response.json()["results"]
+
+    def get_result_ids(self, response):
+        return [item["id"] for item in self.get_results(response)]
+
+    def test_list_contacts_without_tag_filter_returns_all_contacts(self):
+        response = self.client.get("/api/contacts/")
+
+        self.assertCountEqual(
+            self.get_result_ids(response),
+            [
+                self.contact_alpha.id,
+                self.contact_beta.id,
+                self.contact_both.id,
+                self.contact_none.id,
+            ],
+        )
+
+    def test_single_numeric_tag_filter_preserves_existing_behavior(self):
+        response = self.client.get(f"/api/contacts/?tag={self.alpha.id}")
+
+        self.assertCountEqual(
+            self.get_result_ids(response),
+            [self.contact_alpha.id, self.contact_both.id],
+        )
+
+    def test_single_tag_name_preserves_existing_behavior(self):
+        response = self.client.get("/api/contacts/?tag=alpha")
+
+        self.assertCountEqual(
+            self.get_result_ids(response),
+            [self.contact_alpha.id, self.contact_both.id],
+        )
+
+    def test_repeated_tag_filters_match_any_selected_tag_once(self):
+        response = self.client.get(
+            f"/api/contacts/?tag={self.alpha.id}&tag={self.beta.id}"
+        )
+
+        result_ids = self.get_result_ids(response)
+
+        self.assertCountEqual(
+            result_ids,
+            [self.contact_alpha.id, self.contact_beta.id, self.contact_both.id],
+        )
+        self.assertEqual(len(result_ids), len(set(result_ids)))
+
+    def test_repeated_tag_filters_ignore_invalid_values_without_erroring(self):
+        response = self.client.get(
+            f"/api/contacts/?tag={self.alpha.id}&tag=does-not-exist"
+        )
+
+        self.assertCountEqual(
+            self.get_result_ids(response),
+            [self.contact_alpha.id, self.contact_both.id],
+        )
+
+    def test_invalid_tag_values_return_empty_results(self):
+        response = self.client.get("/api/contacts/?tag=does-not-exist")
+
+        self.assertEqual(self.get_result_ids(response), [])
+
+    def test_contacts_list_serializes_assigned_tags(self):
+        response = self.client.get("/api/contacts/")
+
+        contact_alpha = next(
+            item for item in self.get_results(response)
+            if item["id"] == self.contact_alpha.id
+        )
+
+        self.assertEqual(
+            contact_alpha["tags"],
+            [
+                {
+                    "id": self.alpha.id,
+                    "name": self.alpha.name,
+                    "color": self.alpha.color,
+                }
+            ],
+        )

--- a/Server/dggcrm/contacts/views.py
+++ b/Server/dggcrm/contacts/views.py
@@ -25,7 +25,11 @@ class ContactViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
 
         query = self.request.query_params.get("q", "").strip()
-        tag = self.request.query_params.get("tag")
+        tag_values = [
+            value.strip()
+            for value in self.request.query_params.getlist("tag")
+            if value and value.strip()
+        ]
         
         # TODO add querying by event participation
 
@@ -38,12 +42,17 @@ class ContactViewSet(viewsets.ModelViewSet):
                 Q(note__icontains=query)
             )
 
-        if tag:
-            # allow filtering by tag id OR tag name
-            if tag.isdigit():
-                queryset = queryset.filter(taggings__tag__id=tag)
-            else:
-                queryset = queryset.filter(taggings__tag__name__iexact=tag)
+        if tag_values:
+            tag_ids = [int(value) for value in tag_values if value.isdigit()]
+            tag_names = [value for value in tag_values if not value.isdigit()]
+
+            tag_filter = Q()
+            if tag_ids:
+                tag_filter |= Q(taggings__tag__id__in=tag_ids)
+            for tag_name in tag_names:
+                tag_filter |= Q(taggings__tag__name__iexact=tag_name)
+
+            queryset = queryset.filter(tag_filter).distinct()
 
         return queryset
 


### PR DESCRIPTION
Closes #34

## Summary
This PR adds multi-select tag filtering on the contacts page using Mantine `MultiSelect`.

It also updates the contacts API to support repeated `tag` query params while preserving the existing single-tag-by-name behavior, and adds narrow backend test coverage for the filter behavior.

## Changes
- replace the contacts-page single tag filter with a multi-select
- send repeated `tag` query params from the contacts page
- update the contacts API to support repeated tag filters with any-match semantics
- preserve existing single-tag name filtering behavior
- add backend tests for:
  - no tag filter
  - single tag id
  - single tag name
  - repeated tag ids
  - mixed valid/invalid values
  - invalid-only values
  - contacts list tag serialization behavior

## Testing
Ran:

```bash
docker compose -f docker-compose.dev.yaml exec -e DATABASE_URL=postgres://tiny:password@postgres:5432/dggcrm server python manage.py test dggcrm.contacts.tests -v 2