### PR TITLE
allow requests to paths w/ & w/o trailing slash

### DIFF
--- a/Application/app/components/tickets/TicketActions.tsx
+++ b/Application/app/components/tickets/TicketActions.tsx
@@ -74,7 +74,7 @@ export default function TicketActions({ ticket, event, contact }: TicketActionsP
   async function upsertParticipation(participation: SearchSelectOption<CommitmentStatus> | null) {
     if (!event || !contact || !participation) return;
     try {
-      await apiClient.post("/participants", {
+      await apiClient.post("/participants/", {
         event_id: event.id,
         contact_id: contact.id,
         status: participation.raw?.value,

--- a/Application/app/profile/page.tsx
+++ b/Application/app/profile/page.tsx
@@ -37,7 +37,7 @@ function ProfileForm({ user, refresh }: ProfileFormProps) {
   const updateProfile = async () => {
     setError(null);
     try {
-      await apiClient.patch("/auth/user", { first_name: firstName, last_name: lastName });
+      await apiClient.patch("/auth/user/", { first_name: firstName, last_name: lastName });
     } catch {
       setError("Failed to update profile");
     }

--- a/Application/next.config.ts
+++ b/Application/next.config.ts
@@ -1,37 +1,25 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8080";
 
-// Warning if accidently ran in production
 if (!process.env.BACKEND_URL) {
   console.warn("BACKEND_URL not set, falling back to http://localhost:8080");
 } else {
   console.warn(`BACKEND_URL set to ${BACKEND_URL}`);
 }
 
-module.exports = {
+const nextConfig: NextConfig = {
+  skipTrailingSlashRedirect: true,
   async rewrites() {
     return [
-      {
-        source: "/accounts/:path*",
-        destination: `${BACKEND_URL}/accounts/:path*`,
-      },
-      {
-        source: "/api/:path*",
-        destination: `${BACKEND_URL}/api/:path*`,
-      },
-      {
-        source: "/admin/:path*",
-        destination: `${BACKEND_URL}/admin/:path*`,
-      },
-      {
-        source: "/django/:path*",
-        destination: `${BACKEND_URL}/django/:path*`,
-      },
+      { source: "/accounts/:path*/", destination: `${BACKEND_URL}/accounts/:path*/` },
+      { source: "/accounts/:path*", destination: `${BACKEND_URL}/accounts/:path*` },
+      { source: "/api/:path*/", destination: `${BACKEND_URL}/api/:path*/` },
+      { source: "/api/:path*", destination: `${BACKEND_URL}/api/:path*` },
+      { source: "/admin/:path*/", destination: `${BACKEND_URL}/admin/:path*/` },
+      { source: "/admin/:path*", destination: `${BACKEND_URL}/admin/:path*` },
+      { source: "/django/:path*/", destination: `${BACKEND_URL}/django/:path*/` },
+      { source: "/django/:path*", destination: `${BACKEND_URL}/django/:path*` },
     ];
   },
 };

--- a/Application/next.config.ts
+++ b/Application/next.config.ts
@@ -18,19 +18,19 @@ module.exports = {
     return [
       {
         source: "/accounts/:path*",
-        destination: `${BACKEND_URL}/accounts/:path*/`,
+        destination: `${BACKEND_URL}/accounts/:path*`,
       },
       {
         source: "/api/:path*",
-        destination: `${BACKEND_URL}/api/:path*/`,
+        destination: `${BACKEND_URL}/api/:path*`,
       },
       {
         source: "/admin/:path*",
-        destination: `${BACKEND_URL}/admin/:path*/`,
+        destination: `${BACKEND_URL}/admin/:path*`,
       },
       {
         source: "/django/:path*",
-        destination: `${BACKEND_URL}/django/:path*/`,
+        destination: `${BACKEND_URL}/django/:path*`,
       },
     ];
   },

--- a/Server/dggcrm/contacts/urls.py
+++ b/Server/dggcrm/contacts/urls.py
@@ -7,6 +7,7 @@ from .views import (
 )
 
 router = DefaultRouter()
+router.trailing_slash = "/?"
 router.register("contacts", ContactViewSet, basename="contact")
 router.register("tags", TagViewSet, basename="tag")
 router.register("tag-assignments", TagAssignmentViewSet, basename="tag-assignment")

--- a/Server/dggcrm/events/urls.py
+++ b/Server/dggcrm/events/urls.py
@@ -9,6 +9,7 @@ from .views import (
 )
 
 router = DefaultRouter()
+router.trailing_slash = "/?"
 router.register("events", EventViewSet, basename="event")
 router.register(
     "participants",

--- a/Server/dggcrm/tickets/urls.py
+++ b/Server/dggcrm/tickets/urls.py
@@ -11,6 +11,7 @@ from .views import (
 )
 
 router = DefaultRouter()
+router.trailing_slash = "/?"
 router.register("tickets", TicketViewSet, basename="ticket")
 router.register("ticket-types", TicketTypeViewSet, basename="ticket-types")
 router.register("ticket-statuses", TicketStatusesViewSet, basename="ticket-statuses")


### PR DESCRIPTION
the issue is that a post to an incorrect path (like a path without a '/') causes a redirect, which implicitly calls a follow up get with the same incorrect path causing a throw. added a fix to allow endpoints to accept paths w/o trailing '/' 