### PR TITLE
Add restart: unless-stopped to all production services

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -40,6 +40,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    logging:
+      driver: journald
     networks:
       - coolify
       - default
@@ -65,6 +67,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 15s
+    logging:
+      driver: journald
 
   server: &server
     build:
@@ -111,6 +115,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    logging:
+      driver: journald
 
 
   postgres:
@@ -136,6 +142,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging:
+      driver: journald
 
 volumes:
   dggcrm_production_postgres_data:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -4,6 +4,7 @@ services:
       context: .
       dockerfile: ./compose/production/nginx/Dockerfile
     container_name: inhouse_suite_nginx
+    restart: unless-stopped
     depends_on:
       - frontend
       - server
@@ -50,6 +51,7 @@ services:
       dockerfile: ./compose/production/application/Dockerfile
     image: inhouse_suite_frontend
     container_name: inhouse_suite_frontend
+    restart: unless-stopped
     environment:
       - BACKEND_URL=${BACKEND_URL}
     env_file:
@@ -70,6 +72,7 @@ services:
       dockerfile: ./compose/production/server/Dockerfile
     image: inhouse_suite_server
     container_name: inhouse_suite_server
+    restart: unless-stopped
     volumes:
       - dggcrm_production_admin_static_files:/app/staticfiles
     depends_on:
@@ -113,6 +116,7 @@ services:
   postgres:
     image: postgres:18.1
     container_name: inhouse_suite_postgres
+    restart: unless-stopped
     volumes:
       - dggcrm_production_postgres_data:/var/lib/postgresql/18/docker
       - dggcrm_production_postgres_data_backups:/backups


### PR DESCRIPTION
**Problem**

When any production container crashed (Django server, Next.js frontend, nginx, or postgres), Docker left it dead. Recovery required manual intervention, someone had to notice and restart it.

**Change**

Added restart: unless-stopped to all four services in docker-compose.prod.yaml. This is Docker's built-in restart policy and is standard practice for production Compose deployments.

`unless-stopped` behaviour:
  - Restarts automatically after a crash or OOM kill
  - Restarts after a Docker daemon restart or host reboot
  - Does not restart if you manually stop a container (safe for intentional deployments/maintenance)

This does not conflict with Coolify — Coolify respects the compose file's restart settings and handles deployments separately.

I also snuck in another change to change the production docker to log to `journald` rather than json files, this will enable us to persist logs across deploys.

**Verification**

After deploying, confirm with:
```
  # Kill a container and watch it come back
  docker kill inhouse_suite_server
  docker ps | grep inhouse_suite_server

  # Confirm policy is applied
  docker inspect inhouse_suite_server --format '{{.HostConfig.RestartPolicy.Name}}'
  # → unless-stopped
```
