### PR TITLE
Require valid participation status when adding event participants

### DIFF
--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -205,7 +205,10 @@ function AddParticipantModal({
   };
 
   const handleSubmit = async () => {
+    if (!eventStatus) return;
+
     setSubmitting(true);
+
     try {
       if (mode === "add") {
         await Promise.all(
@@ -321,10 +324,11 @@ function AddParticipantModal({
           </Combobox>
         )}
         <Select
-          label="Participation Status"
-          placeholder="Participation Status"
           data={EVENT_PARTICIPATION_STATUSES}
+          label="Participation Status"
           onChange={(s) => setEventStatus(s as EventParticipationStatus)}
+          placeholder="Participation Status"
+          required
           value={eventStatus}
         />
         <PaginatedTable<Contact>
@@ -348,7 +352,7 @@ function AddParticipantModal({
           loading={false}
           noDataText="Select a participant to proceed"
         />
-        <Button onClick={handleSubmit} disabled={submitting}>
+        <Button onClick={handleSubmit} disabled={!eventStatus || submitting}>
           Submit
         </Button>
       </Stack>

--- a/Server/dggcrm/events/serializers.py
+++ b/Server/dggcrm/events/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 
 from ..contacts.models import Contact
 from ..contacts.serializers import ContactSerializer
-from .models import Event, EventParticipation, UsersInEvent
+from .models import CommitmentStatus, Event, EventParticipation, UsersInEvent
 
 User = get_user_model()
 
@@ -35,6 +35,7 @@ class EventParticipationSerializer(serializers.ModelSerializer):
     )
     event = EventSerializer(read_only=True)
     contact = ContactSerializer(read_only=True)
+    status = serializers.ChoiceField(choices=CommitmentStatus.choices)
 
     class Meta:
         model = EventParticipation

--- a/Server/dggcrm/events/tests/test_views.py
+++ b/Server/dggcrm/events/tests/test_views.py
@@ -16,14 +16,14 @@ class TestParticipationCreate:
         response = self.client.post(ENDPOINT, {"event_id": scheduled_event.id, "contact_id": contact.id})
 
         assert response.status_code == 400
-        assert response.data["detail"] == "a valid status is required."
+        assert "status" in response.data
 
     def test_blank_status_returns_400(self, admin_user, scheduled_event, contact):
         self.client.force_authenticate(user=admin_user)
         response = self.client.post(ENDPOINT, {"event_id": scheduled_event.id, "contact_id": contact.id, "status": ""})
 
         assert response.status_code == 400
-        assert response.data["detail"] == "a valid status is required."
+        assert "status" in response.data
 
     def test_invalid_status_returns_400(self, admin_user, scheduled_event, contact):
         self.client.force_authenticate(user=admin_user)
@@ -32,7 +32,7 @@ class TestParticipationCreate:
         )
 
         assert response.status_code == 400
-        assert response.data["detail"] == "a valid status is required."
+        assert "status" in response.data
 
     def test_create_with_status_returns_201(self, admin_user, scheduled_event, contact):
         self.client.force_authenticate(user=admin_user)
@@ -43,6 +43,18 @@ class TestParticipationCreate:
 
         assert response.status_code == 201
         assert EventParticipation.objects.filter(event=scheduled_event, contact=contact).exists()
+
+    def test_create_with_status_with_unknown_status(self, admin_user, scheduled_event, contact):
+        self.client.force_authenticate(user=admin_user)
+        response = self.client.post(
+            ENDPOINT,
+            {"event_id": scheduled_event.id, "contact_id": contact.id, "status": CommitmentStatus.UNKNOWN},
+        )
+
+        assert response.status_code == 201
+        assert EventParticipation.objects.filter(
+            event=scheduled_event, contact=contact, status=CommitmentStatus.UNKNOWN
+        ).exists()
 
     def test_upsert_with_status_returns_200(self, admin_user, scheduled_event, contact, scheduled_participation):
         self.client.force_authenticate(user=admin_user)

--- a/Server/dggcrm/events/tests/test_views.py
+++ b/Server/dggcrm/events/tests/test_views.py
@@ -1,0 +1,56 @@
+import pytest
+from rest_framework.test import APIClient
+
+from dggcrm.events.models import CommitmentStatus, EventParticipation
+
+ENDPOINT = "/api/participants/"
+
+
+@pytest.mark.django_db
+class TestParticipationCreate:
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_missing_status_returns_400(self, admin_user, scheduled_event, contact):
+        self.client.force_authenticate(user=admin_user)
+        response = self.client.post(ENDPOINT, {"event_id": scheduled_event.id, "contact_id": contact.id})
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "a valid status is required."
+
+    def test_blank_status_returns_400(self, admin_user, scheduled_event, contact):
+        self.client.force_authenticate(user=admin_user)
+        response = self.client.post(ENDPOINT, {"event_id": scheduled_event.id, "contact_id": contact.id, "status": ""})
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "a valid status is required."
+
+    def test_invalid_status_returns_400(self, admin_user, scheduled_event, contact):
+        self.client.force_authenticate(user=admin_user)
+        response = self.client.post(
+            ENDPOINT, {"event_id": scheduled_event.id, "contact_id": contact.id, "status": "fake"}
+        )
+
+        assert response.status_code == 400
+        assert response.data["detail"] == "a valid status is required."
+
+    def test_create_with_status_returns_201(self, admin_user, scheduled_event, contact):
+        self.client.force_authenticate(user=admin_user)
+        response = self.client.post(
+            ENDPOINT,
+            {"event_id": scheduled_event.id, "contact_id": contact.id, "status": CommitmentStatus.COMMITTED},
+        )
+
+        assert response.status_code == 201
+        assert EventParticipation.objects.filter(event=scheduled_event, contact=contact).exists()
+
+    def test_upsert_with_status_returns_200(self, admin_user, scheduled_event, contact, scheduled_participation):
+        self.client.force_authenticate(user=admin_user)
+        response = self.client.post(
+            ENDPOINT,
+            {"event_id": scheduled_event.id, "contact_id": contact.id, "status": CommitmentStatus.ATTENDED},
+        )
+
+        assert response.status_code == 200
+        scheduled_participation.refresh_from_db()
+        assert scheduled_participation.status == CommitmentStatus.ATTENDED

--- a/Server/dggcrm/events/views.py
+++ b/Server/dggcrm/events/views.py
@@ -147,12 +147,6 @@ class EventParticipationViewSet(viewsets.ModelViewSet):
         Otherwise, create a new participation.
         """
 
-        if request.data.get("status") not in CommitmentStatus.values:
-            return Response(
-                {"detail": "a valid status is required."},
-                status=rest_status.HTTP_400_BAD_REQUEST,
-            )
-
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 

--- a/Server/dggcrm/events/views.py
+++ b/Server/dggcrm/events/views.py
@@ -147,6 +147,12 @@ class EventParticipationViewSet(viewsets.ModelViewSet):
         Otherwise, create a new participation.
         """
 
+        if request.data.get("status") not in CommitmentStatus.values:
+            return Response(
+                {"detail": "a valid status is required."},
+                status=rest_status.HTTP_400_BAD_REQUEST,
+            )
+
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 


### PR DESCRIPTION
Closes #180 

The event participant form allowed submissions without a participation status, resulting in participants being saved with the model default (UNKNOWN) silently.

  **Changes**
- Frontend (EventView.tsx): marks the status Select as required, disables submit when no status is chosen, and guards handleSubmit with an early return if status is falsy
- Backend (serializers.py): overrides status on EventParticipationSerializer with an explicit ChoiceField, so is_valid rejects missing, blank, and invalid values with a
  field-level 400 (consistent with the rest of the codebase, which uses serializer-driven validation in 8 of 9 places)
- Tests (events/tests/test_views.py): new API-level coverage for missing, blank, invalid, UNKNOWN (still a valid explicit choice), create (201), and upsert (200) cases

**Note on UNKNOWN**
I opted to require the input even when the organizer wants to pick UNKNOWN, to promote data completeness — so missing the input or quickly clicking past it doesn't lose information the organizer actually has. Selecting UNKNOWN explicitly is still supported; it just has to be a deliberate choice.

**Test plan**
  - Open the Add Participant modal, leave status blank → submit is disabled
  - Pick a status, select contacts, submit → participation created with that status
  - task test passes

* Claude helped with writing tests