### PR TITLE
Add GitHub branch rules setup doc

### DIFF
--- a/.github/branch-rules.md
+++ b/.github/branch-rules.md
@@ -1,0 +1,61 @@
+# GitHub branch rules setup
+
+One-time configuration for branch protection on `main` and `dev`. Apply these
+in the repo's GitHub settings. Everything uses **Rulesets** (Settings → Rules
+→ Rulesets), not classic Branch protection.
+
+## 1. Repo settings
+
+In **Settings → General**:
+
+- [ ] Enable **Automatically delete head branches** (cleans up feature branches after merge)
+
+In **Settings → General → Pull Requests**:
+
+- [ ] Allow **squash merging**
+- [ ] Allow **merge commits**
+- [ ] Disable **rebase merging** (optional — keeps history consistent)
+
+## 2. Ruleset: `dev` branch
+
+**Settings → Rules → Rulesets → New branch ruleset**
+
+- **Ruleset name**: `dev branch protection`
+- **Enforcement status**: Active
+- **Target branches**: Include by pattern → `dev`
+- **Bypass list**: `@digitalgroundgame/digital-ground-game` — mode: **For pull requests**
+
+Enable these rules:
+
+- [ ] **Restrict deletions**
+- [ ] **Block force pushes**
+- [ ] **Require a pull request before merging**
+  - Required approvals: **1**
+  - [ ] Dismiss stale pull request approvals when new commits are pushed
+  - [ ] Require conversation resolution before merging
+  - Allowed merge methods: **Squash** only
+- [ ] **Require status checks to pass**
+  - [ ] Require branches to be up to date before merging
+  - Add each CI check name once CI is running (backend tests, frontend tests, lint, migration check)
+
+## 3. Ruleset: `main` branch
+
+**Settings → Rules → Rulesets → New branch ruleset**
+
+- **Ruleset name**: `main branch protection`
+- **Enforcement status**: Active
+- **Target branches**: Include by pattern → `main`
+- **Bypass list**: `@digitalgroundgame/digital-ground-game` — mode: **For pull requests**
+
+Enable these rules:
+
+- [ ] **Restrict deletions**
+- [ ] **Block force pushes**
+- [ ] **Restrict who can push to matching refs** → `@digitalgroundgame/digital-ground-game` only
+- [ ] **Require a pull request before merging**
+  - Required approvals: **0**
+  - [ ] Require conversation resolution before merging
+  - Allowed merge methods: **Merge commit** and **Squash** (merge commit for regular `dev → main` releases, squash available for hotfix branches)
+- [ ] **Require status checks to pass**
+  - [ ] Require branches to be up to date before merging
+  - Same CI checks as `dev`

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ A useful PR description includes:
 
 When opening your PR, use the **Request Review** feature if a specific person has context on the issue or asked for the change. Otherwise, leave it blank — anyone with write access will pick it up.
 
+If you start reviewing a PR and no one is already assigned as a reviewer, assign yourself. This lets other potential reviewers know it's already being looked at so they don't duplicate effort.
+
 Someone with write access will review your PR and may leave comments or request changes. Address each piece of feedback with either a code change or a reply explaining your reasoning. Push new commits to the same branch — the PR updates automatically. Once approved, your PR will be merged into `dev`.
 
 ### 6. Keep your branch up to date


### PR DESCRIPTION
@evan6seven here is a proposal for the branch rules. Let me know if you have any questions or feedback.

Both main and dev get deletion protection, force-push blocks, and a required PR flow. The dev rules require 1 approval, passing CI, and squash-only merges. The main rules restrict pushes and merges to the @digitalgroundgame/digital-ground-game team, require passing CI, and allow merge commits (for dev → main releases) plus squash (for hotfixes). Team leads appear on the bypass list in "For pull requests" mode so they can merge release PRs without a redundant approval while still going through a PR for audit trail.

And here is the proposed flow this supports:

>  Developers branch from dev, open a PR back into dev (1 approval required), and a team lead merges. When ready to release, a team lead opens a PR from dev into main, merging to main auto-deploys to production.

And hot fix flow:

>  For prod-critical fixes, branch from main (not dev), open a PR back into main, and a team lead merges , auto-deploying the fix. Immediately open a follow-up PR from main into dev and merge it, so the fix doesn't regress on the next release.