### PR TITLE
Scope mock OAuth to local dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Python linting and formatting (Server)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.0
+    rev: v0.15.10
     hooks:
       - id: ruff
         name: ruff lint (Python)

--- a/Server/config/settings/test.py
+++ b/Server/config/settings/test.py
@@ -1,3 +1,8 @@
+import os
+
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
 # ruff: noqa: F403
 from .base import *
 

--- a/Server/config/urls.py
+++ b/Server/config/urls.py
@@ -18,13 +18,6 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
-urlpatterns = []
-
-# TODO: only add these paths in local dev (NEVER PRODUCTION)
-urlpatterns += [
-    path("accounts/", include("dggcrm.authmock.urls")),
-]
-
 urlpatterns = [
     # allauth (browser OAuth)
     path("accounts/", include("allauth.urls")),

--- a/Server/dggcrm/authmock/tests/test_urls.py
+++ b/Server/dggcrm/authmock/tests/test_urls.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import sys
+
+import pytest
+from django.urls import NoReverseMatch, reverse
+
+
+def test_mock_oauth_routes_disabled_by_default():
+    with pytest.raises(NoReverseMatch, match="mock-discord_login"):
+        reverse("mock-discord_login")
+
+
+def test_mock_oauth_routes_enabled_in_local_settings():
+    env = os.environ | {
+        "DJANGO_SETTINGS_MODULE": "config.settings.local",
+        "SECRET_KEY": "test-secret",
+        "DATABASE_URL": "sqlite:///:memory:",
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            ("import django; from django.urls import reverse; django.setup(); print(reverse('mock-discord_login'))"),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.stdout.strip().endswith("/accounts/mock-discord/login/")

--- a/Server/requirements.txt
+++ b/Server/requirements.txt
@@ -15,7 +15,7 @@ psycopg[c]==3.3.2
 argparse
 
 # Linting and formatting
-ruff>=0.9.0
+ruff==0.15.10
 pre-commit>=4.0.0
 
 # Testing


### PR DESCRIPTION
## Summary
- remove the redundant mock auth include from `Server/config/urls.py`
- keep mock OAuth available only through local settings via `dggcrm.authmock`
- add a regression test that verifies mock Discord auth is absent under test settings and present under local settings
- unify Ruff to `0.15.10` across `Server/requirements.txt` and `.pre-commit-config.yaml`

## Validation
- `python -m pytest dggcrm/authmock/tests/test_urls.py -v`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `pre-commit run ruff --all-files`

Used AI assistance, human verified. Closes #174
