### PR TITLE
Prevent user from inputting inconsistent date ordering

### DIFF
--- a/Application/app/components/datetime/DateRangePicker.tsx
+++ b/Application/app/components/datetime/DateRangePicker.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { DateTimePicker as MantineDateTimePicker } from "@mantine/dates";
 import { Stack, Group, Text, Popover, Button, Box } from "@mantine/core";
 import { IconCalendar } from "@tabler/icons-react";
 import { useTimezone } from "@/app/components/provider/TimezoneContext";
-import { toUTC, parseToLocal, getTimezoneAbbr, formatDateTime } from "@/app/utils/datetime";
+import { getTimezoneAbbr, formatDateTime } from "@/app/utils/datetime";
 
 export interface DateRangeValue {
   start: string | null;

--- a/Application/app/components/datetime/DateRangePicker.tsx
+++ b/Application/app/components/datetime/DateRangePicker.tsx
@@ -121,6 +121,7 @@ export function DateRangePicker({
               value={draftStart}
               onChange={setDraftStart}
               clearable
+              popoverProps={{ withinPortal: false }}
             />
             <MantineDateTimePicker
               label={`End (${tzAbbr})`}
@@ -128,6 +129,7 @@ export function DateRangePicker({
               onChange={setDraftEnd}
               minDate={draftStart || undefined}
               clearable
+              popoverProps={{ withinPortal: false }}
             />
             <Group justify="flex-end" gap="xs">
               <Button variant="subtle" size="xs" onClick={handleClear}>

--- a/Application/app/components/events/EventTemplateView.tsx
+++ b/Application/app/components/events/EventTemplateView.tsx
@@ -38,8 +38,6 @@ export default function EventTemplateView({ eventType, title = "Events" }: Event
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [start, setStartDate] = useState<string | null>(null);
-  const [end, setEndDate] = useState<string | null>(null);
 
   const form = useForm({
     initialValues: {

--- a/Application/app/components/events/EventTemplateView.tsx
+++ b/Application/app/components/events/EventTemplateView.tsx
@@ -19,7 +19,8 @@ import { apiClient } from "@/app/lib/apiClient";
 import { useForm } from "@mantine/form";
 import EventsTable from "@/app/components/EventsTable";
 import { type Event, type EventType } from "@/app/components/event-utils";
-import { DateTimePicker, DateTime } from "@/app/components/datetime";
+import { DateTime } from "@/app/components/datetime";
+import { DateRangePicker } from "@/app/components/datetime";
 
 interface EventTemplateViewProps {
   eventType: EventType;
@@ -37,6 +38,8 @@ export default function EventTemplateView({ eventType, title = "Events" }: Event
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [start, setStartDate] = useState<string | null>(null);
+  const [end, setEndDate] = useState<string | null>(null);
 
   const form = useForm({
     initialValues: {
@@ -192,20 +195,18 @@ export default function EventTemplateView({ eventType, title = "Events" }: Event
               placeholder="Enter event description (optional)"
               {...form.getInputProps("description")}
             />
-            <DateTimePicker
-              label="Start Date"
+
+            <DateRangePicker
+              label="Event Dates"
               required
-              value={form.values.starts_at}
-              onChange={(val) => form.setFieldValue("starts_at", val || "")}
-              error={form.errors.starts_at as string}
+              value={{ start: form.values.starts_at || null, end: form.values.ends_at || null }}
+              onChange={({ start, end }) => {
+                form.setFieldValue("starts_at", start ?? "");
+                form.setFieldValue("ends_at", end ?? "");
+              }}
+              error={(form.errors.starts_at as string) ?? (form.errors.ends_at as string)}
             />
-            <DateTimePicker
-              label="End Date"
-              required
-              value={form.values.ends_at}
-              onChange={(val) => form.setFieldValue("ends_at", val || "")}
-              error={form.errors.ends_at as string}
-            />
+
             <TextInput
               label="Location Name"
               placeholder="Enter location (optional)"


### PR DESCRIPTION
We actually already had a DateRangePicker with logic for preventing the user from assigning a start date that occurs after an end date. So  I replaced the two date input items  with  one DateRangePicker.

The DateRangePicker had  an issue where the input prompt for dates would disappear; I fixed this as well. 