### PR TITLE
Set static network value for Traefik to `coolify`

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -14,6 +14,7 @@ services:
       - dggcrm_production_admin_static_files:/app/staticfiles
     labels:
     - traefik.enable=true
+    - traefik.docker.network=coolify
     - "traefik.http.routers.inhouse-nginx.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
     - traefik.http.routers.inhouse-nginx.entryPoints=http
     - traefik.http.services.inhouse-nginx.loadbalancer.server.port=80

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -15,8 +15,12 @@ services:
     labels:
     - traefik.enable=true
     - traefik.docker.network=coolify
-    - "traefik.http.routers.inhouse-nginx.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
-    - traefik.http.routers.inhouse-nginx.entryPoints=http
+    - "traefik.http.routers.inhouse-nginx-http.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
+    - traefik.http.routers.inhouse-nginx-http.entryPoints=http
+    - "traefik.http.routers.inhouse-nginx-https.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
+    - traefik.http.routers.inhouse-nginx-https.entryPoints=https
+    - traefik.http.routers.inhouse-nginx-https.tls=true
+    - traefik.http.routers.inhouse-nginx-https.tls.certresolver=letsencrypt
     - traefik.http.services.inhouse-nginx.loadbalancer.server.port=80
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/health"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -13,28 +13,9 @@ services:
     volumes:
       - dggcrm_production_admin_static_files:/app/staticfiles
     labels:
-    - coolify.managed=true
-    - coolify.type=service
-    - coolify.name=inhouse_suite_nginx-<uuid>
-    - coolify.resourceName=nginx
-    - coolify.projectName=inhouse_suite
-    - coolify.serviceName=nginx
-    - coolify.environmentName=production
     - traefik.enable=true
-    - traefik.docker.network=coolify
-    - traefik.http.middlewares.gzip.compress=true
-    - traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https
-    - "traefik.http.routers.http-<uuid>-nginx.entryPoints=http"
-    - "traefik.http.routers.http-<uuid>-nginx.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
-    - "traefik.http.routers.http-<uuid>-nginx.service=http-<uuid>-nginx"
-    - "traefik.http.routers.https-<uuid>-nginx.entryPoints=https"
-    - "traefik.http.routers.https-<uuid>-nginx.middlewares=gzip"
-    - "traefik.http.routers.https-<uuid>-nginx.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
-    - "traefik.http.routers.https-<uuid>-nginx.service=https-<uuid>-nginx"
-    - "traefik.http.routers.https-<uuid>-nginx.tls=true"
-    - "traefik.http.routers.https-<uuid>-nginx.tls.certresolver=letsencrypt"
-    - "traefik.http.services.http-<uuid>-nginx.loadbalancer.server.port=80"
-    - "traefik.http.services.https-<uuid>-nginx.loadbalancer.server.port=80"
+    - "traefik.http.routers.inhouse-nginx.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
+    - traefik.http.routers.inhouse-nginx.entryPoints=http
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/health"]
       interval: 10s

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -14,7 +14,6 @@ services:
       - dggcrm_production_admin_static_files:/app/staticfiles
     labels:
     - traefik.enable=true
-    - traefik.docker.network=coolify
     - "traefik.http.routers.inhouse-nginx-http.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
     - traefik.http.routers.inhouse-nginx-http.entryPoints=http
     - "traefik.http.routers.inhouse-nginx-https.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -14,6 +14,7 @@ services:
       - dggcrm_production_admin_static_files:/app/staticfiles
     labels:
     - traefik.enable=true
+    - traefik.docker.network=coolify
     - "traefik.http.routers.inhouse-nginx-http.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
     - traefik.http.routers.inhouse-nginx-http.entryPoints=http
     - "traefik.http.routers.inhouse-nginx-https.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
@@ -21,6 +22,9 @@ services:
     - traefik.http.routers.inhouse-nginx-https.tls=true
     - traefik.http.routers.inhouse-nginx-https.tls.certresolver=letsencrypt
     - traefik.http.services.inhouse-nginx.loadbalancer.server.port=80
+    networks:
+      - coolify
+      - default
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/health"]
       interval: 10s
@@ -133,3 +137,7 @@ volumes:
   dggcrm_production_postgres_data:
   dggcrm_production_postgres_data_backups:
   dggcrm_production_admin_static_files:
+
+networks:
+  coolify:
+    external: true

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -21,6 +21,7 @@ services:
     - coolify.serviceName=nginx
     - coolify.environmentName=production
     - traefik.enable=true
+    - traefik.docker.network=coolify
     - traefik.http.middlewares.gzip.compress=true
     - traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https
     - "traefik.http.routers.http-<uuid>-nginx.entryPoints=http"
@@ -42,9 +43,6 @@ services:
       start_period: 10s
     logging:
       driver: journald
-    networks:
-      - coolify
-      - default
 
 
   frontend:
@@ -149,7 +147,3 @@ volumes:
   dggcrm_production_postgres_data:
   dggcrm_production_postgres_data_backups:
   dggcrm_production_admin_static_files:
-
-networks:
-  coolify:
-    external: true

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -16,6 +16,7 @@ services:
     - traefik.enable=true
     - "traefik.http.routers.inhouse-nginx.rule=Host(`house.digitalgroundgame.org`) && PathPrefix(`/`)"
     - traefik.http.routers.inhouse-nginx.entryPoints=http
+    - traefik.http.services.inhouse-nginx.loadbalancer.server.port=80
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/health"]
       interval: 10s


### PR DESCRIPTION
## Summary

Fix intermittent 504 Gateway Timeout errors caused by Traefik non-deterministically selecting which Docker network to use when routing to the nginx container

- Pin Traefik to the `coolify` network via [`traefik.docker.network`](https://doc.traefik.io/traefik/reference/install-configuration/providers/docker/#opt-providers-docker-network) label so it always uses the reachable IP
- Simplify Traefik labels: remove redundant `coolify.*` labels (Coolify auto-adds these)
- Use clean router names instead of `<uuid>` placeholders

## Root cause

The nginx container sits on two Docker networks: `coolify` (shared with the Traefik proxy) and the compose `default` network (for reaching frontend/server). Without `traefik.docker.network`, Traefik picks between the two IPs non-deterministically. When it picks the `default` network IP  (which the proxy isn't on) requests time out with a 504.