### PR TITLE
Enhance frontend dev container startup

### DIFF
--- a/compose/dev/application/Dockerfile
+++ b/compose/dev/application/Dockerfile
@@ -2,9 +2,4 @@ FROM node:20
 
 WORKDIR /app
 
-COPY ./Application/package*.json ./
-RUN npm install && npm cache clean --force
-
 ENV PATH=./node_modules/.bin/:$PATH
-
-CMD ["npm", "run", "dev"]

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -15,6 +15,7 @@ services:
     environment:
       - BACKEND_URL=http://server:8080
       - NEXT_PUBLIC_USE_MOCK_OAUTH=true
+    command: sh -c "npm ci && npm run dev"
     ports:
       - '3030:3030'
 


### PR DESCRIPTION
I had a problem after the Sentry package was added: my docker container was out of sync with the new package requirement. I wanted to automate any changes to package.json so the dev environment stays working.

## Changes

- run `npm ci && npm run dev` from `docker-compose.dev.yaml`

## Why

The frontend source is bind-mounted into `/app`, while `node_modules` stays container-owned. Running `npm ci` at container start keeps dependencies aligned with the mounted `package.json` and `package-lock.json`, which avoids missing-module errors like `@sentry/nextjs` after dependency changes.

## Verification

- built the frontend dev image with `docker build -f compose/dev/application/Dockerfile .`
- ran the app and saw it loaded