### PR TITLE
Improve ticket detail navigation controls

### DIFF
--- a/Application/app/components/tickets/TicketView.tsx
+++ b/Application/app/components/tickets/TicketView.tsx
@@ -22,7 +22,6 @@ import {
   ScrollArea,
   Avatar,
 } from "@mantine/core";
-import { useRouter } from "next/navigation";
 import { IconSend } from "@tabler/icons-react";
 import { getStatusColor, getPriorityColor } from "./TicketTable";
 import TicketDescription from "./TicketDescription";
@@ -130,15 +129,7 @@ export default function TicketView({
 }
 
 function TitleCard({ ticket }: { ticket: Ticket }) {
-  const router = useRouter();
-  return (
-    <Group justify="space-between">
-      <Title order={2}>{ticket.title}</Title>
-      <Button variant="outline" onClick={() => router.push("/tickets")}>
-        Back to List
-      </Button>
-    </Group>
-  );
+  return <Title order={2}>{ticket.title}</Title>;
 }
 
 function CallInstructionsCard({ ticket }: { ticket: Ticket }) {

--- a/Application/app/tickets/[id]/page.tsx
+++ b/Application/app/tickets/[id]/page.tsx
@@ -2,19 +2,18 @@
 
 import { useEffect, useState } from "react";
 import { apiClient } from "@/app/lib/apiClient";
-import { Loader, Center, Text, ActionIcon } from "@mantine/core";
+import { Loader, Center, Text, Container, Group, Button } from "@mantine/core";
 import TicketView, {
   TimelineEntry,
   type TimelineShowType,
 } from "@/app/components/tickets/TicketView";
 import { type Ticket } from "@/app/components/tickets/ticket-utils";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 //import TicketView, { type TimelineShowType } from "@/app/components/tickets/TicketView";
 
 export default function TicketInfoPage() {
   const { id } = useParams<{ id: string }>();
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const [ticket, setTicket] = useState<Ticket | null>(null);
@@ -104,19 +103,33 @@ export default function TicketInfoPage() {
   if (!ticket) return null;
 
   return (
-    <div style={{ display: "flex", alignItems: "stretch", minHeight: "100%" }}>
-      <ActionIcon
-        variant="subtle"
-        color="gray"
-        onClick={() => navigate("previous")}
-        disabled={navLoading}
-        style={{ alignSelf: "stretch", height: "auto", width: 40, borderRadius: 0 }}
-        aria-label="Previous ticket"
-      >
-        <IconChevronLeft size={24} />
-      </ActionIcon>
+    <>
+      <Container size="xl" pt="xl" pb={0}>
+        <Group justify="space-between" wrap="wrap" gap="sm">
+          <Button
+            variant="subtle"
+            color="gray"
+            leftSection={<IconChevronLeft size={18} />}
+            onClick={() => navigate("previous")}
+            loading={navLoading}
+            aria-label="Previous ticket"
+          >
+            Previous Ticket
+          </Button>
+          <Button
+            variant="subtle"
+            color="gray"
+            rightSection={<IconChevronRight size={18} />}
+            onClick={() => navigate("next")}
+            loading={navLoading}
+            aria-label="Next ticket"
+          >
+            Next Ticket
+          </Button>
+        </Group>
+      </Container>
 
-      <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ minWidth: 0 }}>
         <TicketView
           ticket={ticket}
           timeline={timeline}
@@ -126,17 +139,6 @@ export default function TicketInfoPage() {
           setTimeline={setTimeline}
         />
       </div>
-
-      <ActionIcon
-        variant="subtle"
-        color="gray"
-        onClick={() => navigate("next")}
-        disabled={navLoading}
-        style={{ alignSelf: "stretch", height: "auto", width: 40, borderRadius: 0 }}
-        aria-label="Next ticket"
-      >
-        <IconChevronRight size={24} />
-      </ActionIcon>
-    </div>
+    </>
   );
 }

--- a/Application/app/tickets/[id]/page.tsx
+++ b/Application/app/tickets/[id]/page.tsx
@@ -9,12 +9,12 @@ import TicketView, {
 } from "@/app/components/tickets/TicketView";
 import { type Ticket } from "@/app/components/tickets/ticket-utils";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
-import { useParams, useSearchParams } from "next/navigation";
-//import TicketView, { type TimelineShowType } from "@/app/components/tickets/TicketView";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 export default function TicketInfoPage() {
   const { id } = useParams<{ id: string }>();
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   const [ticket, setTicket] = useState<Ticket | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary

<img width="1281" height="669" alt="Screenshot 2026-04-16 at 3 36 36 PM" src="https://github.com/user-attachments/assets/907ae375-c7bf-42a9-94df-780217998e30" />

Improves the `/tickets/[id]` detail page navigation UX. 

## Changes

- Moves ticket navigation controls from edge-mounted icon buttons to a top navigation row to avoid accidental navigation.
- Adds explicit `Previous Ticket` and `Next Ticket` labels for upfront understanding of the buttons.
- Removes the redundant `Back to List` button from the ticket detail view (does the same thing as Tickets button which is visible in the UI).
- Cleans up unused navigation-related imports

## Testing

- Ran the app

Closes #190 