### PR TITLE
Remove hard-code host env var so that the actual env var is used

### DIFF
--- a/compose/production/server/entrypoint
+++ b/compose/production/server/entrypoint
@@ -3,7 +3,6 @@ set -e
 
 echo "Starting container…"
 
-export POSTGRES_HOST=postgres
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
 echo $POSTGRES_HOST


### PR DESCRIPTION
This is the only change required for the new db. This `POSTGRES_HOST` is hard-coded in, but it should really be coming from the env vars anyway. This env var is already set to this same value, so deploying this before switching over to a new db won't cause any issues.

<img width="1094" height="236" alt="image" src="https://github.com/user-attachments/assets/1caa8460-774e-4ec2-aa0a-12c340890502" />
