### PR TITLE
Add missing arg to apiClient post call

### DIFF
--- a/Application/app/components/management/UsersSection.tsx
+++ b/Application/app/components/management/UsersSection.tsx
@@ -147,7 +147,8 @@ export default function UsersSection({ onUserCreated }: Props) {
   const handleToggleActive = async (user: ManagedUser) => {
     try {
       const result = await apiClient.post<{ is_active: boolean }>(
-        `/management/users/${user.id}/toggle-active/`
+        `/management/users/${user.id}/toggle-active/`,
+        {}
       );
       setUsers((prev) =>
         prev.map((u) => (u.id === user.id ? { ...u, is_active: result.is_active } : u))


### PR DESCRIPTION
Looks like the previously merged PR (#202) had a build error, I'm surprised CI didn't catch this. I've made [a ticket](https://github.com/digitalgroundgame/in-house-mgmt/issues/205) to look into it.

The `apiClient.post` requires a second body object arg, just adding an empty object.