### PR TITLE
Add event management instructions to homepage

### DIFF
--- a/Application/app/home/page.tsx
+++ b/Application/app/home/page.tsx
@@ -1,9 +1,40 @@
+import { Container, Title, Paper, Text, Stack, Group, ThemeIcon, Anchor } from "@mantine/core";
+
+const steps: (string | React.ReactNode)[] = [
+  <>
+    Go to the <Anchor href="/events">Events tab</Anchor>
+  </>,
+  "Click on Add Event",
+  "Fill out your event details and press Submit",
+  "Select your new event",
+  "Click the Add Participant button",
+  "Search for participants by Discord server name",
+  'Set Participant Status to "Attended"',
+  "You're done! Thank you!",
+];
+
 export default function HomePage() {
   return (
-    <div>
-      <h1>Home Page</h1>
-      <p>Needs further discussion before implementation</p>
-      <p>Maybe can give join My Calls and My Profile information</p>
-    </div>
+    <Container size="sm" py="xl">
+      <Title order={2} mb="lg">
+        Steps to Manage an Event
+      </Title>
+      <Paper p="xl" withBorder radius="md">
+        <Stack gap="md">
+          {steps.map((step, i) => (
+            <Group key={i} gap="md" wrap="nowrap" align="flex-start">
+              <ThemeIcon size="lg" radius="xl" variant="light">
+                <Text size="sm" fw={700}>
+                  {i + 1}
+                </Text>
+              </ThemeIcon>
+              <Text size="md" pt={4}>
+                {step}
+              </Text>
+            </Group>
+          ))}
+        </Stack>
+      </Paper>
+    </Container>
   );
 }


### PR DESCRIPTION
Replaces placeholder content with a step-by-step guide for managing events, using numbered badges and a link to the Events page.

<img width="1233" height="968" alt="Screenshot 2026-04-17 at 1 11 12 PM" src="https://github.com/user-attachments/assets/414e69aa-bf36-426d-817c-33d53696f34d" />
