### PR TITLE
Use Discord global_name over username for contact display names

### DIFF
--- a/Server/dggcrm/discord/client.py
+++ b/Server/dggcrm/discord/client.py
@@ -108,7 +108,10 @@ class DiscordClient:
                 members.append(
                     {
                         "id": user.get("id"),
-                        "display_name": member.get("nick") or user.get("username") or f"Discord {user.get('id')}",
+                        "display_name": member.get("nick")
+                        or user.get("global_name")
+                        or user.get("username")
+                        or f"Discord {user.get('id')}",
                     }
                 )
 
@@ -192,7 +195,10 @@ class DiscordClient:
                 members.append(
                     {
                         "id": user.get("id"),
-                        "display_name": member.get("nick") or user.get("username") or f"Discord {user.get('id')}",
+                        "display_name": member.get("nick")
+                        or user.get("global_name")
+                        or user.get("username")
+                        or f"Discord {user.get('id')}",
                         "role_ids": member.get("roles", []),
                     }
                 )

--- a/Server/dggcrm/discord/tests/test_client.py
+++ b/Server/dggcrm/discord/tests/test_client.py
@@ -187,3 +187,81 @@ class TestDiscordClient:
 
         assert result == set()
         assert len(responses.calls) == 1  # No retry
+
+
+class TestDisplayNamePriority:
+    """Tests for display name resolution: nick > global_name > username > fallback"""
+
+    def _mock_member(self, user_id="123", nick=None, global_name=None, username=None):
+        user = {"id": user_id}
+        if global_name is not None:
+            user["global_name"] = global_name
+        if username is not None:
+            user["username"] = username
+        member = {"user": user, "roles": []}
+        if nick is not None:
+            member["nick"] = nick
+        return member
+
+    def _setup_response(self, members):
+        responses.add(
+            responses.GET,
+            f"{DISCORD_API_BASE}/guilds/123456789/members?limit=1000",
+            json=members,
+            status=200,
+        )
+
+    @responses.activate
+    def test_prefers_nick_over_global_name(self):
+        client = DiscordClient(token="test-token", guild_id=123456789)
+        self._setup_response([self._mock_member(nick="CoolNick", global_name="SpacePanda", username="xpanda_42")])
+
+        result = client.fetch_all_members()
+
+        assert result[0]["display_name"] == "CoolNick"
+
+    @responses.activate
+    def test_prefers_global_name_over_username(self):
+        client = DiscordClient(token="test-token", guild_id=123456789)
+        self._setup_response([self._mock_member(global_name="SpacePanda", username="xpanda_42")])
+
+        result = client.fetch_all_members()
+
+        assert result[0]["display_name"] == "SpacePanda"
+
+    @responses.activate
+    def test_falls_back_to_username(self):
+        client = DiscordClient(token="test-token", guild_id=123456789)
+        self._setup_response([self._mock_member(username="xpanda_42")])
+
+        result = client.fetch_all_members()
+
+        assert result[0]["display_name"] == "xpanda_42"
+
+    @responses.activate
+    def test_falls_back_to_discord_id(self):
+        client = DiscordClient(token="test-token", guild_id=123456789)
+        self._setup_response([self._mock_member(user_id="99999")])
+
+        result = client.fetch_all_members()
+
+        assert result[0]["display_name"] == "Discord 99999"
+
+    @responses.activate
+    def test_skips_null_global_name(self):
+        client = DiscordClient(token="test-token", guild_id=123456789)
+        member = {"user": {"id": "123", "global_name": None, "username": "xpanda_42"}, "roles": []}
+        self._setup_response([member])
+
+        result = client.fetch_all_members()
+
+        assert result[0]["display_name"] == "xpanda_42"
+
+    @responses.activate
+    def test_display_name_in_fetch_all_members_with_roles(self):
+        client = DiscordClient(token="test-token", guild_id=123456789)
+        self._setup_response([self._mock_member(global_name="SpacePanda", username="xpanda_42")])
+
+        result = client.fetch_all_members_with_roles()
+
+        assert result[0]["display_name"] == "SpacePanda"


### PR DESCRIPTION
## Summary

  - Fix display name resolution to prefer Discord's `global_name` over `username`
  - Previous priority: `nick` > `username` — users with a display name set in Discord still showed their raw username (e.g., `xpanda_42` instead of `SpacePanda`)
  - New priority: `nick` > `global_name` > `username` > fallback — matches what users actually see in the Discord app

  ## Test plan

  - [ ] Run `python -m pytest dggcrm/discord/tests/test_client.py -v` — 6 new tests for display name priority
  - [ ] Deploy and trigger a Discord sync — verify contacts update to their global display names
  - [ ] Verify contacts with server nicknames still show the nickname

  > Tests were written with AI assistance.
