### PR TITLE
Remove postgres from production docker in favor of a coolify hosted db

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -69,8 +69,6 @@ services:
     restart: unless-stopped
     volumes:
       - dggcrm_production_admin_static_files:/app/staticfiles
-    depends_on:
-      - postgres
     env_file:
       - path: ./.envs/.production/.postgres
         required: false
@@ -113,35 +111,7 @@ services:
       - default
 
 
-  postgres:
-    image: postgres:18.1
-    container_name: inhouse_suite_postgres
-    restart: unless-stopped
-    volumes:
-      - dggcrm_production_postgres_data:/var/lib/postgresql/18/docker
-      - dggcrm_production_postgres_data_backups:/backups
-    env_file:
-      - path: ./.envs/.production/.postgres
-        required: false
-    environment:
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - POSTGRES_PORT=${POSTGRES_PORT}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-    expose:
-      - "5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    logging:
-      driver: journald
-
 volumes:
-  dggcrm_production_postgres_data:
-  dggcrm_production_postgres_data_backups:
   dggcrm_production_admin_static_files:
 
 networks:


### PR DESCRIPTION
## Summary

- Remove the PostgreSQL service from docker-compose.prod.yaml in favor of the standalone Coolify-managed instance
- Removes `depends_on: postgres` from the server service, the full postgres service definition, and the two postgres named volumes
- The server's `wait-for-it` entrypoint, POSTGRES_* env vars, and env_file reference are unchanged — they now point to the standalone DB

## Follow-up actions (on server, after deploy)

1. Confirm the app is healthy at house.digitalgroundgame.org
2. Remove the old container: `docker rm inhouse_suite_postgres`
3. Remove the old volumes: `docker volume rm dggcrm_production_postgres_data dggcrm_production_postgres_data_backups`

## Test plan

- [x] Stopped the compose postgres on the server (`docker stop inhouse_suite_postgres`) and confirmed the app continues to function against the standalone DB

Closes #207 

