### PR TITLE
Implement event edit workflow 

### DIFF
--- a/Application/app/components/EventsTable.tsx
+++ b/Application/app/components/EventsTable.tsx
@@ -60,8 +60,10 @@ export default function EventsTable({
                       </Text>
                     )}
                   </Table.Td>
-                  <Table.Td>
-                    <Text size="sm">{event.status_display}</Text>
+                  <Table.Td style={{ whiteSpace: "normal" }}>
+                    <Text size="sm" style={{ whiteSpace: "normal", overflowWrap: "anywhere" }}>
+                      {event.status_display}
+                    </Text>
                   </Table.Td>
                   <Table.Td>
                     <DateRange start={event.starts_at} end={event.ends_at} size="sm" />

--- a/Application/app/components/event-utils.ts
+++ b/Application/app/components/event-utils.ts
@@ -7,6 +7,7 @@ export interface Event {
   event_type: EventType;
   event_status: string;
   status_display: string;
+  editable_fields?: string[];
   name: string;
   description: string | null;
   location_name: string | null;

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -102,7 +102,7 @@ function EventViewMain({ event }: { event: Event }) {
 
   const canEditEvent = (currentEvent.editable_fields?.length ?? 0) > 0;
 
-  const updateEvent = async (payload: Partial<Event>) => {
+  const updateEvent = async (payload: Partial<Event>): Promise<Event> => {
     const updated = await apiClient.patch<Event>(`/events/${currentEvent.id}`, payload);
     setCurrentEvent(updated);
     return updated;

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -9,10 +9,14 @@ import { User } from "@/app/components/provider/types";
 import {
   Event,
   EventParticipation,
+  getStatusColor,
   getEventParticipationStatusColor,
   UsersInEvent,
 } from "@/app/components/event-utils";
 import { BackendPaginatedResults, useBackend, useBackendMutation } from "@/app/lib/api";
+import { apiClient } from "@/app/lib/apiClient";
+import { DateTimePicker } from "@/app/components/datetime";
+import { DateTime } from "@/app/components/datetime/DateTime";
 import {
   Text,
   Paper,
@@ -35,14 +39,16 @@ import {
   Combobox,
   useCombobox,
   Tabs,
+  Textarea,
+  ActionIcon,
+  Tooltip,
 } from "@mantine/core";
-import { IconSearch } from "@tabler/icons-react";
+import { IconPencil, IconSearch } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import getCookie from "@/app/utils/cookie";
-import { formatDateTime } from "@/app/utils/datetime";
 
 const EVENT_PARTICIPATION_STATUSES = [
   "UNKNOWN",
@@ -64,83 +70,379 @@ export default function EventView({ event }: { event: Event | undefined }) {
 }
 
 function EventViewMain({ event }: { event: Event }) {
+  const [currentEvent, setCurrentEvent] = useState(event);
+  const [isEditing, setIsEditing] = useState(false);
+  const [summaryDraft, setSummaryDraft] = useState({
+    name: event.name,
+    description: event.description ?? "",
+  });
+  const [metadataDraft, setMetadataDraft] = useState({
+    status: event.event_status,
+    locationName: event.location_name ?? "",
+    locationAddress: event.location_address ?? "",
+    startsAt: event.starts_at,
+    endsAt: event.ends_at,
+  });
+  const [isSavingEventEdits, setIsSavingEventEdits] = useState(false);
+
+  useEffect(() => {
+    setCurrentEvent(event);
+    setSummaryDraft({
+      name: event.name,
+      description: event.description ?? "",
+    });
+    setMetadataDraft({
+      status: event.event_status,
+      locationName: event.location_name ?? "",
+      locationAddress: event.location_address ?? "",
+      startsAt: event.starts_at,
+      endsAt: event.ends_at,
+    });
+  }, [event]);
+
+  const canEditEvent = (currentEvent.editable_fields?.length ?? 0) > 0;
+
+  const updateEvent = async (payload: Partial<Event>) => {
+    const updated = await apiClient.patch<Event>(`/events/${currentEvent.id}`, payload);
+    setCurrentEvent(updated);
+    return updated;
+  };
+
+  const saveEventEdits = async () => {
+    setIsSavingEventEdits(true);
+    try {
+      await updateEvent({
+        name: summaryDraft.name,
+        description: summaryDraft.description,
+        event_status: metadataDraft.status,
+        location_name: metadataDraft.locationName,
+        location_address: metadataDraft.locationAddress,
+        starts_at: metadataDraft.startsAt,
+        ends_at: metadataDraft.endsAt,
+      });
+
+      notifications.show({
+        title: "Event updated",
+        message: "Saved event changes.",
+        color: "green",
+      });
+      setIsEditing(false);
+    } catch (error) {
+      console.error(error);
+      notifications.show({
+        title: "Save failed",
+        message: "Could not update the event details.",
+        color: "red",
+      });
+    } finally {
+      setIsSavingEventEdits(false);
+    }
+  };
+
+  const cancelEditing = () => {
+    setSummaryDraft({
+      name: currentEvent.name,
+      description: currentEvent.description ?? "",
+    });
+    setMetadataDraft({
+      status: currentEvent.event_status,
+      locationName: currentEvent.location_name ?? "",
+      locationAddress: currentEvent.location_address ?? "",
+      startsAt: currentEvent.starts_at,
+      endsAt: currentEvent.ends_at,
+    });
+    setIsEditing(false);
+  };
+
   return (
-    <Grid>
-      <GridCol span={{ base: 12, md: 8 }}>
-        <Paper withBorder p="md">
-          <Stack gap="sm">
-            <Title>{event.name}</Title>
-            <Divider />
-            <Text>{event.description}</Text>
-          </Stack>
-        </Paper>
+    <Grid align="flex-start">
+      <GridCol style={{ flex: 1, minWidth: 0 }}>
+        {canEditEvent && (
+          <Group justify="flex-end" mb="md">
+            {!isEditing ? (
+              <Tooltip label="Edit Event">
+                <ActionIcon
+                  size="md"
+                  variant="filled"
+                  onClick={() => setIsEditing(true)}
+                  aria-label="Edit Event"
+                >
+                  <IconPencil size={16} />
+                </ActionIcon>
+              </Tooltip>
+            ) : (
+              <>
+                <Button
+                  size="xs"
+                  onClick={saveEventEdits}
+                  loading={isSavingEventEdits}
+                  disabled={
+                    summaryDraft.name === currentEvent.name &&
+                    summaryDraft.description === (currentEvent.description ?? "") &&
+                    metadataDraft.status === currentEvent.event_status &&
+                    metadataDraft.locationName === (currentEvent.location_name ?? "") &&
+                    metadataDraft.locationAddress === (currentEvent.location_address ?? "") &&
+                    metadataDraft.startsAt === currentEvent.starts_at &&
+                    metadataDraft.endsAt === currentEvent.ends_at
+                  }
+                >
+                  Save
+                </Button>
+                <Button size="xs" variant="outline" color="red" onClick={cancelEditing}>
+                  Cancel
+                </Button>
+              </>
+            )}
+          </Group>
+        )}
+        <EventSummaryCard
+          event={currentEvent}
+          isEditing={isEditing}
+          summaryDraft={summaryDraft}
+          setSummaryDraft={setSummaryDraft}
+        />
         <Tabs defaultValue="participants" mt="md">
           <Tabs.List>
             <Tabs.Tab value="participants">Participants</Tabs.Tab>
             <Tabs.Tab value="users">Users</Tabs.Tab>
           </Tabs.List>
-          <Tabs.Panel value="participants">
-            <EventViewContactTable event={event} />
+          <Tabs.Panel value="participants" style={{ minWidth: "432px" }}>
+            <EventViewContactTable event={currentEvent} />
           </Tabs.Panel>
           <Tabs.Panel value="users">
-            <EventViewUsersTable event={event} />
+            <EventViewUsersTable event={currentEvent} />
           </Tabs.Panel>
         </Tabs>
       </GridCol>
-      <EventViewMetadata event={event} />
+      <GridCol style={{ flex: "0 0 239px", maxWidth: "239px", minWidth: "239px" }}>
+        <EventViewMetadata
+          event={currentEvent}
+          isEditing={isEditing}
+          metadataDraft={metadataDraft}
+          setMetadataDraft={setMetadataDraft}
+        />
+      </GridCol>
     </Grid>
   );
 }
 
-function EventViewMetadata({ event }: { event: Event }) {
+function EventSummaryCard({
+  event,
+  isEditing,
+  summaryDraft,
+  setSummaryDraft,
+}: {
+  event: Event;
+  isEditing: boolean;
+  summaryDraft: {
+    name: string;
+    description: string;
+  };
+  setSummaryDraft: React.Dispatch<
+    React.SetStateAction<{
+      name: string;
+      description: string;
+    }>
+  >;
+}) {
+  const canEditName = event.editable_fields?.includes("name") ?? false;
+  const canEditDescription = event.editable_fields?.includes("description") ?? false;
+  const descriptionText = event.description?.trim() ?? "";
+  const hasDescription = descriptionText.length > 0;
+
   return (
-    <GridCol span={{ base: 12, md: 4 }}>
-      <Paper withBorder p="sm">
-        <Box mt={4} mb={4}>
-          <Text c="dimmed" size="sm">
-            Event Status
-          </Text>
-          <Badge color={getEventParticipationStatusColor(event.status_display)}>
-            {event.status_display}
-          </Badge>
-        </Box>
-        <Divider />
-        <Box mt={4} mb={4}>
-          <Text c="dimmed" size="sm">
-            Location Name
-          </Text>
-          <Text>{event.location_name}</Text>
-        </Box>
-        <Divider />
+    <Box>
+      <Stack gap="sm">
+        {canEditName && isEditing ? (
+          <TextInput
+            value={summaryDraft.name}
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setSummaryDraft((current) => ({ ...current, name: value }));
+            }}
+            variant="unstyled"
+            size="xl"
+            styles={{
+              input: {
+                fontSize: "var(--mantine-h1-font-size)",
+                fontWeight: 700,
+                lineHeight: "var(--mantine-h1-line-height)",
+                padding: 0,
+              },
+            }}
+          />
+        ) : (
+          <Title>{event.name}</Title>
+        )}
+        {canEditDescription && isEditing ? (
+          <>
+            <Divider />
+            <Textarea
+              value={summaryDraft.description}
+              onChange={(e) => {
+                const value = e.currentTarget.value;
+                setSummaryDraft((current) => ({ ...current, description: value }));
+              }}
+              autosize
+              minRows={5}
+              variant="unstyled"
+              styles={{
+                input: {
+                  fontSize: "var(--mantine-font-size-md)",
+                  lineHeight: "var(--mantine-line-height)",
+                  padding: 0,
+                },
+              }}
+            />
+          </>
+        ) : hasDescription ? (
+          <>
+            <Divider />
+            <Text style={{ whiteSpace: "pre-wrap" }}>{descriptionText}</Text>
+          </>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}
+
+function EventViewMetadata({
+  event,
+  isEditing,
+  metadataDraft,
+  setMetadataDraft,
+}: {
+  event: Event;
+  isEditing: boolean;
+  metadataDraft: {
+    status: string;
+    locationName: string;
+    locationAddress: string;
+    startsAt: string;
+    endsAt: string;
+  };
+  setMetadataDraft: React.Dispatch<
+    React.SetStateAction<{
+      status: string;
+      locationName: string;
+      locationAddress: string;
+      startsAt: string;
+      endsAt: string;
+    }>
+  >;
+}) {
+  const canEditStatus = event.editable_fields?.includes("event_status") ?? false;
+  const canEditLocation =
+    (event.editable_fields?.includes("location_name") ?? false) ||
+    (event.editable_fields?.includes("location_address") ?? false);
+  const canEditDates =
+    (event.editable_fields?.includes("starts_at") ?? false) ||
+    (event.editable_fields?.includes("ends_at") ?? false);
+
+  return (
+    <Paper withBorder p="sm">
+      <Box mt={4} mb={4}>
+        <Text c="dimmed" size="sm">
+          Event Status
+        </Text>
+        {canEditStatus && isEditing ? (
+          <Select
+            data={[
+              { value: "draft", label: "Draft" },
+              { value: "scheduled", label: "Scheduled" },
+              { value: "completed", label: "Completed" },
+              { value: "canceled", label: "Canceled" },
+            ]}
+            value={metadataDraft.status}
+            onChange={(value) => {
+              setMetadataDraft((current) => ({
+                ...current,
+                status: value ?? event.event_status,
+              }));
+            }}
+          />
+        ) : (
+          <Badge color={getStatusColor(event.status_display)}>{event.status_display}</Badge>
+        )}
+      </Box>
+      <Box mt={4} mb={4}>
+        {canEditLocation && isEditing ? (
+          <>
+            <Text c="dimmed" size="sm">
+              Location Name
+            </Text>
+            <TextInput
+              value={metadataDraft.locationName}
+              onChange={(e) => {
+                const value = e.currentTarget.value;
+                setMetadataDraft((current) => ({ ...current, locationName: value }));
+              }}
+              placeholder="Location name"
+            />
+          </>
+        ) : (
+          <>
+            <Text c="dimmed" size="sm">
+              Location Display
+            </Text>
+            <Text>{event.location_display}</Text>
+          </>
+        )}
+      </Box>
+      {canEditLocation && isEditing && (
         <Box mt={4} mb={4}>
           <Text c="dimmed" size="sm">
             Address
           </Text>
-          <Text mb={4}>{event.location_address}</Text>
+          <Textarea
+            value={metadataDraft.locationAddress}
+            onChange={(e) => {
+              const value = e.currentTarget.value;
+              setMetadataDraft((current) => ({ ...current, locationAddress: value }));
+            }}
+            autosize
+            minRows={2}
+            placeholder="Address"
+          />
         </Box>
-        <Divider />
-        <Box mt={4} mb={4}>
-          <Text c="dimmed" size="sm">
-            Location Display
-          </Text>
-          <Text>{event.location_display}</Text>
-        </Box>
-        <Divider />
-        <Box mt={4} mb={4}>
-          <Text c="dimmed" size="sm">
-            Start Date
-          </Text>
-          <Text>{formatDateTime(event.starts_at)}</Text>
-        </Box>
-        <Divider />
-        <Box mt={4} mb={4}>
-          <Text c="dimmed" size="sm">
-            End Date
-          </Text>
-          <Text>{formatDateTime(event.ends_at)}</Text>
-        </Box>
-      </Paper>
-    </GridCol>
+      )}
+      <Box mt={4} mb={4}>
+        <Text c="dimmed" size="sm">
+          Start Date
+        </Text>
+        {canEditDates && isEditing ? (
+          <DateTimePicker
+            value={metadataDraft.startsAt}
+            onChange={(value) =>
+              setMetadataDraft((current) => ({
+                ...current,
+                startsAt: value ?? current.startsAt,
+              }))
+            }
+          />
+        ) : (
+          <DateTime value={event.starts_at} size="sm" mt={4} />
+        )}
+      </Box>
+      <Box mt={4} mb={4}>
+        <Text c="dimmed" size="sm">
+          End Date
+        </Text>
+        {canEditDates && isEditing ? (
+          <DateTimePicker
+            value={metadataDraft.endsAt}
+            onChange={(value) =>
+              setMetadataDraft((current) => ({
+                ...current,
+                endsAt: value ?? current.endsAt,
+              }))
+            }
+          />
+        ) : (
+          <DateTime value={event.ends_at} size="sm" mt={4} />
+        )}
+      </Box>
+    </Paper>
   );
 }
 
@@ -462,8 +764,23 @@ function EventViewContactTable({ event }: { event: Event }) {
                   </Table.Td>
                 ),
                 (ep) => (
-                  <Table.Td key={ep.status}>
-                    <Badge color={getEventParticipationStatusColor(ep.status)}>
+                  <Table.Td
+                    key={ep.status}
+                    style={{
+                      whiteSpace: "nowrap",
+                      width: "1%",
+                    }}
+                  >
+                    <Badge
+                      color={getEventParticipationStatusColor(ep.status)}
+                      styles={{
+                        root: {
+                          whiteSpace: "nowrap",
+                          width: "max-content",
+                          minWidth: "max-content",
+                        },
+                      }}
+                    >
                       {ep.status_display}
                     </Badge>
                   </Table.Td>

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -16,7 +16,6 @@ import {
 import { BackendPaginatedResults, useBackend, useBackendMutation } from "@/app/lib/api";
 import { apiClient } from "@/app/lib/apiClient";
 import { DateTimePicker } from "@/app/components/datetime";
-import { DateTime } from "@/app/components/datetime/DateTime";
 import {
   Text,
   Paper,
@@ -49,6 +48,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import getCookie from "@/app/utils/cookie";
+import { formatDateTime } from "@/app/utils/datetime";
 
 const EVENT_PARTICIPATION_STATUSES = [
   "UNKNOWN",
@@ -338,6 +338,16 @@ function EventViewMetadata({
   const canEditDates =
     (event.editable_fields?.includes("starts_at") ?? false) ||
     (event.editable_fields?.includes("ends_at") ?? false);
+  const metadataInputStyles = {
+    input: {
+      fontSize: "var(--mantine-font-size-md)",
+      fontWeight: 400,
+      lineHeight: "var(--mantine-line-height)",
+      fontFamily: "var(--mantine-font-family)",
+      color: "var(--mantine-color-text)",
+      padding: 0,
+    },
+  } as const;
 
   return (
     <Paper withBorder p="sm">
@@ -360,6 +370,9 @@ function EventViewMetadata({
                 status: value ?? event.event_status,
               }));
             }}
+            variant="unstyled"
+            size="md"
+            styles={metadataInputStyles}
           />
         ) : (
           <Badge color={getStatusColor(event.status_display)}>{event.status_display}</Badge>
@@ -378,6 +391,9 @@ function EventViewMetadata({
                 setMetadataDraft((current) => ({ ...current, locationName: value }));
               }}
               placeholder="Location name"
+              variant="unstyled"
+              size="md"
+              styles={metadataInputStyles}
             />
           </>
         ) : (
@@ -403,6 +419,9 @@ function EventViewMetadata({
             autosize
             minRows={2}
             placeholder="Address"
+            variant="unstyled"
+            size="md"
+            styles={metadataInputStyles}
           />
         </Box>
       )}
@@ -413,6 +432,11 @@ function EventViewMetadata({
         {canEditDates && isEditing ? (
           <DateTimePicker
             value={metadataDraft.startsAt}
+            valueFormat="MM/DD/YY, hh:mm A"
+            timePickerProps={{ format: "12h" }}
+            variant="unstyled"
+            size="md"
+            styles={metadataInputStyles}
             onChange={(value) =>
               setMetadataDraft((current) => ({
                 ...current,
@@ -421,7 +445,7 @@ function EventViewMetadata({
             }
           />
         ) : (
-          <DateTime value={event.starts_at} size="sm" mt={4} />
+          <Text>{formatDateTime(event.starts_at)}</Text>
         )}
       </Box>
       <Box mt={4} mb={4}>
@@ -431,6 +455,11 @@ function EventViewMetadata({
         {canEditDates && isEditing ? (
           <DateTimePicker
             value={metadataDraft.endsAt}
+            valueFormat="MM/DD/YY, hh:mm A"
+            timePickerProps={{ format: "12h" }}
+            variant="unstyled"
+            size="md"
+            styles={metadataInputStyles}
             onChange={(value) =>
               setMetadataDraft((current) => ({
                 ...current,
@@ -439,7 +468,7 @@ function EventViewMetadata({
             }
           />
         ) : (
-          <DateTime value={event.ends_at} size="sm" mt={4} />
+          <Text>{formatDateTime(event.ends_at)}</Text>
         )}
       </Box>
     </Paper>

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -16,6 +16,7 @@ import {
 import { BackendPaginatedResults, useBackend, useBackendMutation } from "@/app/lib/api";
 import { apiClient } from "@/app/lib/apiClient";
 import { DateTimePicker } from "@/app/components/datetime";
+import { type UseFormReturnType, useForm } from "@mantine/form";
 import {
   Text,
   Paper,
@@ -45,7 +46,7 @@ import {
 import { IconPencil, IconSearch } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import getCookie from "@/app/utils/cookie";
 import { formatDateTime } from "@/app/utils/datetime";
@@ -60,6 +61,28 @@ const EVENT_PARTICIPATION_STATUSES = [
 ] as const;
 type EventParticipationStatus = (typeof EVENT_PARTICIPATION_STATUSES)[number];
 
+interface EventEditFormValues {
+  name: string;
+  description: string;
+  status: string;
+  locationName: string;
+  locationAddress: string;
+  startsAt: string;
+  endsAt: string;
+}
+
+function getEventFormValues(event: Event): EventEditFormValues {
+  return {
+    name: event.name,
+    description: event.description ?? "",
+    status: event.event_status,
+    locationName: event.location_name ?? "",
+    locationAddress: event.location_address ?? "",
+    startsAt: event.starts_at,
+    endsAt: event.ends_at,
+  };
+}
+
 export default function EventView({ event }: { event: Event | undefined }) {
   return (
     <Container py="xl" size="xl">
@@ -72,33 +95,10 @@ export default function EventView({ event }: { event: Event | undefined }) {
 function EventViewMain({ event }: { event: Event }) {
   const [currentEvent, setCurrentEvent] = useState(event);
   const [isEditing, setIsEditing] = useState(false);
-  const [summaryDraft, setSummaryDraft] = useState({
-    name: event.name,
-    description: event.description ?? "",
-  });
-  const [metadataDraft, setMetadataDraft] = useState({
-    status: event.event_status,
-    locationName: event.location_name ?? "",
-    locationAddress: event.location_address ?? "",
-    startsAt: event.starts_at,
-    endsAt: event.ends_at,
-  });
   const [isSavingEventEdits, setIsSavingEventEdits] = useState(false);
-
-  useEffect(() => {
-    setCurrentEvent(event);
-    setSummaryDraft({
-      name: event.name,
-      description: event.description ?? "",
-    });
-    setMetadataDraft({
-      status: event.event_status,
-      locationName: event.location_name ?? "",
-      locationAddress: event.location_address ?? "",
-      startsAt: event.starts_at,
-      endsAt: event.ends_at,
-    });
-  }, [event]);
+  const form = useForm<EventEditFormValues>({
+    initialValues: getEventFormValues(event),
+  });
 
   const canEditEvent = (currentEvent.editable_fields?.length ?? 0) > 0;
 
@@ -111,15 +111,18 @@ function EventViewMain({ event }: { event: Event }) {
   const saveEventEdits = async () => {
     setIsSavingEventEdits(true);
     try {
-      await updateEvent({
-        name: summaryDraft.name,
-        description: summaryDraft.description,
-        event_status: metadataDraft.status,
-        location_name: metadataDraft.locationName,
-        location_address: metadataDraft.locationAddress,
-        starts_at: metadataDraft.startsAt,
-        ends_at: metadataDraft.endsAt,
+      const updated = await updateEvent({
+        name: form.values.name,
+        description: form.values.description,
+        event_status: form.values.status,
+        location_name: form.values.locationName,
+        location_address: form.values.locationAddress,
+        starts_at: form.values.startsAt,
+        ends_at: form.values.endsAt,
       });
+      const values = getEventFormValues(updated);
+      form.setValues(values);
+      form.resetDirty(values);
 
       notifications.show({
         title: "Event updated",
@@ -140,17 +143,9 @@ function EventViewMain({ event }: { event: Event }) {
   };
 
   const cancelEditing = () => {
-    setSummaryDraft({
-      name: currentEvent.name,
-      description: currentEvent.description ?? "",
-    });
-    setMetadataDraft({
-      status: currentEvent.event_status,
-      locationName: currentEvent.location_name ?? "",
-      locationAddress: currentEvent.location_address ?? "",
-      startsAt: currentEvent.starts_at,
-      endsAt: currentEvent.ends_at,
-    });
+    const values = getEventFormValues(currentEvent);
+    form.setValues(values);
+    form.resetDirty(values);
     setIsEditing(false);
   };
 
@@ -176,15 +171,7 @@ function EventViewMain({ event }: { event: Event }) {
                   size="xs"
                   onClick={saveEventEdits}
                   loading={isSavingEventEdits}
-                  disabled={
-                    summaryDraft.name === currentEvent.name &&
-                    summaryDraft.description === (currentEvent.description ?? "") &&
-                    metadataDraft.status === currentEvent.event_status &&
-                    metadataDraft.locationName === (currentEvent.location_name ?? "") &&
-                    metadataDraft.locationAddress === (currentEvent.location_address ?? "") &&
-                    metadataDraft.startsAt === currentEvent.starts_at &&
-                    metadataDraft.endsAt === currentEvent.ends_at
-                  }
+                  disabled={!form.isDirty()}
                 >
                   Save
                 </Button>
@@ -195,12 +182,7 @@ function EventViewMain({ event }: { event: Event }) {
             )}
           </Group>
         )}
-        <EventSummaryCard
-          event={currentEvent}
-          isEditing={isEditing}
-          summaryDraft={summaryDraft}
-          setSummaryDraft={setSummaryDraft}
-        />
+        <EventSummaryCard event={currentEvent} isEditing={isEditing} form={form} />
         <Tabs defaultValue="participants" mt="md">
           <Tabs.List>
             <Tabs.Tab value="participants">Participants</Tabs.Tab>
@@ -215,12 +197,7 @@ function EventViewMain({ event }: { event: Event }) {
         </Tabs>
       </GridCol>
       <GridCol style={{ flex: "0 0 239px", maxWidth: "239px", minWidth: "239px" }}>
-        <EventViewMetadata
-          event={currentEvent}
-          isEditing={isEditing}
-          metadataDraft={metadataDraft}
-          setMetadataDraft={setMetadataDraft}
-        />
+        <EventViewMetadata event={currentEvent} isEditing={isEditing} form={form} />
       </GridCol>
     </Grid>
   );
@@ -229,21 +206,11 @@ function EventViewMain({ event }: { event: Event }) {
 function EventSummaryCard({
   event,
   isEditing,
-  summaryDraft,
-  setSummaryDraft,
+  form,
 }: {
   event: Event;
   isEditing: boolean;
-  summaryDraft: {
-    name: string;
-    description: string;
-  };
-  setSummaryDraft: React.Dispatch<
-    React.SetStateAction<{
-      name: string;
-      description: string;
-    }>
-  >;
+  form: UseFormReturnType<EventEditFormValues>;
 }) {
   const canEditName = event.editable_fields?.includes("name") ?? false;
   const canEditDescription = event.editable_fields?.includes("description") ?? false;
@@ -255,11 +222,7 @@ function EventSummaryCard({
       <Stack gap="sm">
         {canEditName && isEditing ? (
           <TextInput
-            value={summaryDraft.name}
-            onChange={(e) => {
-              const value = e.currentTarget.value;
-              setSummaryDraft((current) => ({ ...current, name: value }));
-            }}
+            {...form.getInputProps("name")}
             variant="unstyled"
             size="xl"
             styles={{
@@ -278,11 +241,7 @@ function EventSummaryCard({
           <>
             <Divider />
             <Textarea
-              value={summaryDraft.description}
-              onChange={(e) => {
-                const value = e.currentTarget.value;
-                setSummaryDraft((current) => ({ ...current, description: value }));
-              }}
+              {...form.getInputProps("description")}
               autosize
               minRows={5}
               variant="unstyled"
@@ -309,27 +268,11 @@ function EventSummaryCard({
 function EventViewMetadata({
   event,
   isEditing,
-  metadataDraft,
-  setMetadataDraft,
+  form,
 }: {
   event: Event;
   isEditing: boolean;
-  metadataDraft: {
-    status: string;
-    locationName: string;
-    locationAddress: string;
-    startsAt: string;
-    endsAt: string;
-  };
-  setMetadataDraft: React.Dispatch<
-    React.SetStateAction<{
-      status: string;
-      locationName: string;
-      locationAddress: string;
-      startsAt: string;
-      endsAt: string;
-    }>
-  >;
+  form: UseFormReturnType<EventEditFormValues>;
 }) {
   const canEditStatus = event.editable_fields?.includes("event_status") ?? false;
   const canEditLocation =
@@ -363,13 +306,8 @@ function EventViewMetadata({
               { value: "completed", label: "Completed" },
               { value: "canceled", label: "Canceled" },
             ]}
-            value={metadataDraft.status}
-            onChange={(value) => {
-              setMetadataDraft((current) => ({
-                ...current,
-                status: value ?? event.event_status,
-              }));
-            }}
+            value={form.values.status}
+            onChange={(value) => form.setFieldValue("status", value ?? event.event_status)}
             variant="unstyled"
             size="md"
             styles={metadataInputStyles}
@@ -385,11 +323,7 @@ function EventViewMetadata({
               Location Name
             </Text>
             <TextInput
-              value={metadataDraft.locationName}
-              onChange={(e) => {
-                const value = e.currentTarget.value;
-                setMetadataDraft((current) => ({ ...current, locationName: value }));
-              }}
+              {...form.getInputProps("locationName")}
               placeholder="Location name"
               variant="unstyled"
               size="md"
@@ -411,11 +345,7 @@ function EventViewMetadata({
             Address
           </Text>
           <Textarea
-            value={metadataDraft.locationAddress}
-            onChange={(e) => {
-              const value = e.currentTarget.value;
-              setMetadataDraft((current) => ({ ...current, locationAddress: value }));
-            }}
+            {...form.getInputProps("locationAddress")}
             autosize
             minRows={2}
             placeholder="Address"
@@ -431,18 +361,13 @@ function EventViewMetadata({
         </Text>
         {canEditDates && isEditing ? (
           <DateTimePicker
-            value={metadataDraft.startsAt}
+            value={form.values.startsAt}
             valueFormat="MM/DD/YY, hh:mm A"
             timePickerProps={{ format: "12h" }}
             variant="unstyled"
             size="md"
             styles={metadataInputStyles}
-            onChange={(value) =>
-              setMetadataDraft((current) => ({
-                ...current,
-                startsAt: value ?? current.startsAt,
-              }))
-            }
+            onChange={(value) => form.setFieldValue("startsAt", value ?? form.values.startsAt)}
           />
         ) : (
           <Text>{formatDateTime(event.starts_at)}</Text>
@@ -454,18 +379,13 @@ function EventViewMetadata({
         </Text>
         {canEditDates && isEditing ? (
           <DateTimePicker
-            value={metadataDraft.endsAt}
+            value={form.values.endsAt}
             valueFormat="MM/DD/YY, hh:mm A"
             timePickerProps={{ format: "12h" }}
             variant="unstyled"
             size="md"
             styles={metadataInputStyles}
-            onChange={(value) =>
-              setMetadataDraft((current) => ({
-                ...current,
-                endsAt: value ?? current.endsAt,
-              }))
-            }
+            onChange={(value) => form.setFieldValue("endsAt", value ?? form.values.endsAt)}
           />
         ) : (
           <Text>{formatDateTime(event.ends_at)}</Text>

--- a/Server/dggcrm/events/permissions.py
+++ b/Server/dggcrm/events/permissions.py
@@ -24,6 +24,26 @@ def get_event_visibility_filter(user):
     return q
 
 
+def can_change_event(user, event):
+    if not user or not user.is_authenticated:
+        return False
+
+    # Superuser bypass
+    if user.is_superuser:
+        return True
+
+    # Global edit
+    if user.has_perm("events.change_all_events"):
+        return True
+
+    # Assigned edit
+    if user.has_perm("events.change_assigned_event"):
+        return event.users.filter(user=user).exists()
+
+    # Default deny
+    return False
+
+
 class EventObjectPermission(BasePermission):
     """
     Unified object-level permission for Events.
@@ -66,18 +86,7 @@ class EventObjectPermission(BasePermission):
             return False
 
         # ---------- WRITE ----------
-        if not user.has_perm("events.change_event"):
-            return False
-
-        # Global edit
-        if user.has_perm("events.change_all_events"):
-            return True
-
-        # Assigned edit
-        if user.has_perm("events.change_assigned_event"):
-            return event.users.filter(user=user).exists()
-
-        return False
+        return can_change_event(user, event)
 
 
 def get_participation_visibility_filter(user):

--- a/Server/dggcrm/events/serializers.py
+++ b/Server/dggcrm/events/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from ..contacts.models import Contact
 from ..contacts.serializers import ContactSerializer
 from .models import CommitmentStatus, Event, EventParticipation, UsersInEvent
+from .permissions import can_change_event
 
 User = get_user_model()
 
@@ -11,11 +12,37 @@ User = get_user_model()
 class EventSerializer(serializers.ModelSerializer):
     status_display = serializers.CharField(source="get_event_status_display", read_only=True)
     location_display = serializers.CharField(read_only=True)
+    editable_fields = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
         fields = "__all__"
-        read_only_fields = ["id", "created_at", "location_display", "modified_at", "status_display"]
+        read_only_fields = [
+            "id",
+            "created_at",
+            "location_display",
+            "modified_at",
+            "status_display",
+        ]
+
+    def get_editable_fields(self, event):
+        request = self.context.get("request")
+        user = request.user if request else None
+
+        if not can_change_event(user, event):
+            return []
+
+        return sorted(
+            {
+                "name",
+                "description",
+                "location_name",
+                "location_address",
+                "starts_at",
+                "ends_at",
+                "event_status",
+            }
+        )
 
 
 class EventParticipationSerializer(serializers.ModelSerializer):

--- a/Server/dggcrm/events/tests/test_views.py
+++ b/Server/dggcrm/events/tests/test_views.py
@@ -1,7 +1,7 @@
 import pytest
 from rest_framework.test import APIClient
 
-from dggcrm.events.models import CommitmentStatus, EventParticipation
+from dggcrm.events.models import CommitmentStatus, EventParticipation, EventStatus
 
 ENDPOINT = "/api/participants/"
 
@@ -66,3 +66,92 @@ class TestParticipationCreate:
         assert response.status_code == 200
         scheduled_participation.refresh_from_db()
         assert scheduled_participation.status == CommitmentStatus.ATTENDED
+
+
+@pytest.mark.django_db
+class TestEventEditWorkflow:
+    def setup_method(self):
+        self.client = APIClient()
+
+    def test_event_detail_includes_editable_fields_for_assigned_editor(
+        self,
+        regular_user,
+        scheduled_event,
+        assigned_scheduled_event,
+        view_event_permission,
+        change_event_permission,
+        change_assigned_event_permission,
+    ):
+        regular_user.user_permissions.add(
+            view_event_permission,
+            change_event_permission,
+            change_assigned_event_permission,
+        )
+        self.client.force_authenticate(user=regular_user)
+
+        response = self.client.get(f"/api/events/{scheduled_event.id}/")
+
+        assert response.status_code == 200
+        assert sorted(response.data["editable_fields"]) == [
+            "description",
+            "ends_at",
+            "event_status",
+            "location_address",
+            "location_name",
+            "name",
+            "starts_at",
+        ]
+
+    def test_event_detail_includes_no_editable_fields_without_edit_permission(
+        self,
+        regular_user,
+        scheduled_event,
+        assigned_scheduled_event,
+        view_event_permission,
+    ):
+        regular_user.user_permissions.add(view_event_permission)
+        self.client.force_authenticate(user=regular_user)
+
+        response = self.client.get(f"/api/events/{scheduled_event.id}/")
+
+        assert response.status_code == 200
+        assert response.data["editable_fields"] == []
+
+    def test_patch_updates_event_status_for_assigned_editor(
+        self,
+        regular_user,
+        scheduled_event,
+        assigned_scheduled_event,
+        change_event_permission,
+        change_assigned_event_permission,
+    ):
+        regular_user.user_permissions.add(
+            change_event_permission,
+            change_assigned_event_permission,
+        )
+        self.client.force_authenticate(user=regular_user)
+
+        response = self.client.patch(
+            f"/api/events/{scheduled_event.id}/",
+            {"event_status": EventStatus.COMPLETED},
+        )
+
+        assert response.status_code == 200
+        scheduled_event.refresh_from_db()
+        assert scheduled_event.event_status == EventStatus.COMPLETED
+        assert response.data["event_status"] == EventStatus.COMPLETED
+
+    def test_patch_denied_without_edit_permission(
+        self,
+        regular_user,
+        scheduled_event,
+        assigned_scheduled_event,
+    ):
+        self.client.force_authenticate(user=regular_user)
+
+        response = self.client.patch(
+            f"/api/events/{scheduled_event.id}/",
+            {"event_status": EventStatus.COMPLETED},
+        )
+
+        assert response.status_code == 403


### PR DESCRIPTION
Completes part 1 of #100

https://github.com/user-attachments/assets/7980f27a-d41f-489e-b984-a5336d58f071

**Summary**  
This PR adds an in-place event edit workflow to the event detail page. It introduces backend support for field-level event editability and updates the frontend to let authorized users edit core event fields directly from the event view.

**What changed**

- Added editable_fields to the event serializer so the frontend can determine which event fields are editable; currently this maps event-level edit access to a fixed set of editable fields.
- Extracted event write authorization into a shared can_change_event(...) helper and reused it from event permissions and serializer editability logic.
- Updated the event detail UI to support edit mode for:
    - event name
    - description
    - event status
    - location name / address
    - start / end date
- Added save/cancel editing flow on the event detail page.
- Improved the event detail layout:
    - dedicated metadata panel
    - fixed-width sidebar
    - better handling for status text in tables
    - participant panel minimum width
- Added targeted backend tests covering:
    - editable field exposure for permitted users
    - no editable fields for non-editors
    - event status updates through the normal event PATCH endpoint
    - denied updates without permission

**Testing**

- ./.venv/bin/python -m pytest dggcrm/events/tests/test_views.py dggcrm/events/tests/test_event_permissions.py
- Manual testing