### PR TITLE
Add type check to pre-commit and lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   pre-commit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run type check
-        run: npm run type:check
-
-      - name: Run linter
-        run: npm run lint
-
       - name: Run tests
         run: npm run test:run
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   frontend:
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run type check
+        run: npm run type:check
 
       - name: Run linter
         run: npm run lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
   # JavaScript/TypeScript formatting (Application)
   - repo: local
     hooks:
+      - id: tsc
+        name: tsc (TypeScript)
+        entry: bash -c 'cd Application && npx tsc --noEmit'
+        language: system
+        files: ^Application/.*\.(ts|tsx)$
+        pass_filenames: false
       - id: prettier
         name: prettier (TypeScript)
         entry: bash -c 'cd Application && npx prettier --write .'

--- a/Application/app/components/management/UsersSection.tsx
+++ b/Application/app/components/management/UsersSection.tsx
@@ -146,8 +146,7 @@ export default function UsersSection({ onUserCreated }: Props) {
   const handleToggleActive = async (user: ManagedUser) => {
     try {
       const result = await apiClient.post<{ is_active: boolean }>(
-        `/management/users/${user.id}/toggle-active/`,
-        {}
+        `/management/users/${user.id}/toggle-active/`
       );
       setUsers((prev) =>
         prev.map((u) => (u.id === user.id ? { ...u, is_active: result.is_active } : u))

--- a/Application/app/components/management/UsersSection.tsx
+++ b/Application/app/components/management/UsersSection.tsx
@@ -146,7 +146,8 @@ export default function UsersSection({ onUserCreated }: Props) {
   const handleToggleActive = async (user: ManagedUser) => {
     try {
       const result = await apiClient.post<{ is_active: boolean }>(
-        `/management/users/${user.id}/toggle-active/`
+        `/management/users/${user.id}/toggle-active/`,
+        {}
       );
       setUsers((prev) =>
         prev.map((u) => (u.id === user.id ? { ...u, is_active: result.is_active } : u))

--- a/Application/package.json
+++ b/Application/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "type:check": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
  ## Summary
  - Add `tsc --noEmit` pre-commit hook to catch type errors before commit
  - Add `type:check` npm script to `Application/package.json`
  - Remove redundant lint step from the Test workflow — already covered by the Lint workflow via pre-commit
  - Fix CI triggers to also run on `dev` branch (previously CI only triggered on `main`, so it never ran on normal PRs)

  ## Test plan
  - [x] Run `cd Application && npm run type:check` locally
  - [x] Run `pre-commit run tsc --all-files` to verify the hook
  - [x] Confirm both CI workflows trigger on this PR
  - [x] Confirm a ts error actually fails the CI ([f56061b](https://github.com/digitalgroundgame/in-house-mgmt/pull/223/commits/f56061be83dc60d33da733bb38a718559ec84f9b))
