### PR TITLE
fix: do not refresh page when updating tickets

### DIFF
--- a/Application/app/components/tickets/TicketView.test.tsx
+++ b/Application/app/components/tickets/TicketView.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent, waitFor } from "../../../test-utils/render";
+import TicketView from "./TicketView";
+import { Ticket } from "./ticket-utils";
+import { apiClient } from "@/app/lib/apiClient";
+
+vi.mock("@/app/lib/apiClient", () => ({
+  apiClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockTicket: Ticket = {
+  id: 1,
+  title: "Test Ticket",
+  description: "Test Description",
+  ticket_status: "OPEN",
+  status_display: "Open",
+  priority: 1,
+  priority_display: "Low",
+  ticket_type: "ISSUE",
+  type_display: "Issue",
+  assigned_to: null,
+  assigned_to_username: null,
+  reported_by: 1,
+  reported_by_username: "reporter",
+  contact: null,
+  contact_display: null,
+  event: null,
+  event_display: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  editable_fields: ["ticket_status", "assigned_to", "priority", "ticket_type"],
+};
+
+describe("TicketView", () => {
+  it("calls onUpdate when ticket status is updated", async () => {
+    const onUpdate = vi.fn();
+    vi.mocked(apiClient.patch).mockResolvedValue({});
+    vi.mocked(apiClient.get).mockImplementation((path: string) => {
+      if (path === "/auth/user") return Promise.resolve({ id: 1, username: "admin" });
+      if (path.includes("ticket-statuses")) {
+        return Promise.resolve([
+          { value: "OPEN", label: "Open" },
+          { value: "CLOSED", label: "Closed" },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    render(
+      <TicketView
+        ticket={mockTicket}
+        timeline={[]}
+        timelineLoading={false}
+        showType="all"
+        onShowTypeChange={() => {}}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const currentStatus = screen.getByText("Open");
+    await userEvent.click(currentStatus);
+
+    const closedOption = await screen.findByText("Closed");
+    await userEvent.click(closedOption);
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith("/tickets/1/status/", {
+        ticket_status: "CLOSED",
+      });
+      expect(onUpdate).toHaveBeenCalled();
+    });
+  });
+
+  it("calls onUpdate when ticket is claimed", async () => {
+    const onUpdate = vi.fn();
+    vi.mocked(apiClient.post).mockResolvedValue({});
+    vi.mocked(apiClient.get).mockImplementation((path: string) => {
+      if (path === "/auth/user") return Promise.resolve({ id: 1, username: "admin" });
+      return Promise.resolve([]);
+    });
+
+    render(
+      <TicketView
+        ticket={mockTicket}
+        timeline={[]}
+        timelineLoading={false}
+        showType="all"
+        onShowTypeChange={() => {}}
+        onUpdate={onUpdate}
+      />
+    );
+
+    const claimButton = screen.getByRole("button", { name: /claim ticket/i });
+    await userEvent.click(claimButton);
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith("/tickets/1/claim/", {});
+      expect(onUpdate).toHaveBeenCalled();
+    });
+  });
+});

--- a/Application/app/components/tickets/TicketView.tsx
+++ b/Application/app/components/tickets/TicketView.tsx
@@ -26,7 +26,7 @@ import { IconSend } from "@tabler/icons-react";
 import { getStatusColor, getPriorityColor } from "./TicketTable";
 import TicketDescription from "./TicketDescription";
 import { Ticket, TicketType } from "./ticket-utils";
-import ContactSearch, { Contact } from "@/app/components/ContactSearch";
+import { Contact } from "@/app/components/ContactSearch";
 import { SearchSelect, SearchSelectOption } from "@/app/components/SearchSelect";
 import { EnumSelect, EnumSelectOption } from "@/app/components/EnumSelect";
 import { useUser } from "@/app/components/provider/UserContext";
@@ -57,6 +57,7 @@ interface TicketViewProps {
   showType: TimelineShowType;
   onShowTypeChange: (value: TimelineShowType) => void;
   setTimeline?: React.Dispatch<React.SetStateAction<TimelineEntry[]>>;
+  onUpdate: () => void;
 }
 
 export default function TicketView({
@@ -66,6 +67,7 @@ export default function TicketView({
   showType,
   onShowTypeChange,
   setTimeline,
+  onUpdate,
 }: TicketViewProps) {
   const [contact, setContact] = useState<Contact | null>(null);
   const [event, setEvent] = useState<Event | null>(null);
@@ -115,7 +117,7 @@ export default function TicketView({
         </Grid.Col>
         <Grid.Col span={{ base: 12, md: 4 }}>
           <Stack gap="md">
-            <TicketMetadataCard ticket={ticket} />
+            <TicketMetadataCard ticket={ticket} onUpdate={onUpdate} />
             <TicketActions
               ticket={ticket}
               contact={contact ?? undefined}
@@ -161,7 +163,7 @@ function CallInstructionsCard({ ticket }: { ticket: Ticket }) {
   );
 }
 
-function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
+function TicketMetadataCard({ ticket, onUpdate }: { ticket: Ticket; onUpdate: () => void }) {
   const [loading, setLoading] = useState(false);
   const isClaimed = Boolean(ticket.assigned_to);
   const { user } = useUser();
@@ -229,7 +231,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
       } else {
         await apiClient.post(`/tickets/${ticket.id}/claim/`, {});
       }
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Failed to update ticket claim status");
@@ -245,7 +247,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
         ticket_status: status.id,
       });
       setTicketStatus(status);
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Error updating status");
@@ -260,7 +262,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
         assigned_to: option?.raw?.id ?? null,
       });
       setAssignedTo(option);
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Error updating assigned_to");
@@ -275,7 +277,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
         contact: option?.raw?.id ?? null,
       });
       setContact(option);
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Error updating contact");
@@ -288,7 +290,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
         event: option?.raw?.id ?? null,
       });
       setEvent(option);
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Error updating event");
@@ -302,7 +304,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
         priority: option.id,
       });
       setPriority(option);
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Error updating priority");
@@ -316,7 +318,7 @@ function TicketMetadataCard({ ticket }: { ticket: Ticket }) {
         ticket_type: option.id,
       });
       setTicketType(option);
-      window.location.reload();
+      onUpdate();
     } catch (err) {
       console.error(err);
       alert("Error updating ticket type");
@@ -549,7 +551,7 @@ interface TicketTimelineProps {
   showType: TimelineShowType;
   onShowTypeChange: (value: TimelineShowType) => void;
   ticketId: number;
-  onRefresh?: () => void;
+  onUpdate?: () => void;
   setTimeline?: React.Dispatch<React.SetStateAction<TimelineEntry[]>>;
 }
 
@@ -642,6 +644,7 @@ function TicketTimeline({
         `/tickets/${ticketId}/timeline/?show=${showType}`
       );
       setTimeline?.(Array.isArray(data) ? data : (data.results ?? []));
+      onUpdate?.();
     } catch (err) {
       console.error("Failed to post comment", err);
     } finally {

--- a/Application/app/lib/apiClient.ts
+++ b/Application/app/lib/apiClient.ts
@@ -23,10 +23,11 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 }
 
 export const apiClient = {
-  get: <T>(path: string) => request<T>(path),
-  post: <T>(path: string, data: object) =>
-    request<T>(path, { method: "POST", body: JSON.stringify(data) }),
-  patch: <T>(path: string, data: object) =>
-    request<T>(path, { method: "PATCH", body: JSON.stringify(data) }),
-  delete: (path: string) => request<void>(path, { method: "DELETE" }),
+  get: <T>(path: string, options?: RequestInit) => request<T>(path, { ...options, method: "GET" }),
+  post: <T>(path: string, data: object, options?: RequestInit) =>
+    request<T>(path, { ...options, method: "POST", body: JSON.stringify(data) }),
+  patch: <T>(path: string, data: object, options?: RequestInit) =>
+    request<T>(path, { ...options, method: "PATCH", body: JSON.stringify(data) }),
+  delete: (path: string, options?: RequestInit) =>
+    request<void>(path, { ...options, method: "DELETE" }),
 };

--- a/Application/app/tickets/[id]/page.tsx
+++ b/Application/app/tickets/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { apiClient } from "@/app/lib/apiClient";
 import { Loader, Center, Text, Container, Group, Button } from "@mantine/core";
 import TicketView, {
@@ -15,6 +15,9 @@ export default function TicketInfoPage() {
   const { id } = useParams<{ id: string }>();
   const searchParams = useSearchParams();
   const router = useRouter();
+
+  const ticketAbortControllerRef = useRef<AbortController | null>(null);
+  const timelineAbortControllerRef = useRef<AbortController | null>(null);
 
   const [ticket, setTicket] = useState<Ticket | null>(null);
   const [loading, setLoading] = useState(true);
@@ -44,45 +47,74 @@ export default function TicketInfoPage() {
     }
   };
 
-  useEffect(() => {
+  const fetchTicket = useCallback(async () => {
     if (!id) return;
 
-    const fetchTicket = async () => {
-      try {
-        setLoading(true);
-        const data = await apiClient.get<Ticket>(`/tickets/${id}`);
-        setTicket(data);
-      } catch (err) {
-        console.error(err);
-        setError(`${err}`);
-      } finally {
+    ticketAbortControllerRef.current?.abort();
+    ticketAbortControllerRef.current = new AbortController();
+
+    try {
+      setTicket((prevTicket) => {
+        if (!prevTicket) setLoading(true);
+        return prevTicket;
+      });
+
+      const data = await apiClient.get<Ticket>(`/tickets/${id}`, {
+        signal: ticketAbortControllerRef.current.signal,
+      });
+      setTicket(data);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AbortError") {
+        return;
+      }
+      console.error(err);
+      setError(`${err}`);
+    } finally {
+      if (ticketAbortControllerRef.current?.signal.aborted === false) {
         setLoading(false);
       }
-    };
-
-    fetchTicket();
+    }
   }, [id]);
 
-  useEffect(() => {
+  const fetchTimeline = useCallback(async () => {
     if (!id) return;
 
-    const fetchTimeline = async () => {
-      try {
-        setTimelineLoading(true);
-        const data = await apiClient.get<{ results?: TimelineEntry[] } | TimelineEntry[]>(
-          `/tickets/${id}/timeline/?show=${showType}`
-        );
-        const entries = Array.isArray(data) ? data : (data.results ?? []);
-        setTimeline(entries);
-      } catch (err) {
-        console.error(err);
-      } finally {
+    timelineAbortControllerRef.current?.abort();
+    timelineAbortControllerRef.current = new AbortController();
+
+    try {
+      setTimelineLoading(true);
+      const data = await apiClient.get<{ results?: TimelineEntry[] } | TimelineEntry[]>(
+        `/tickets/${id}/timeline/?show=${showType}`,
+        { signal: timelineAbortControllerRef.current.signal }
+      );
+      const entries = Array.isArray(data) ? data : (data.results ?? []);
+      setTimeline(entries);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "AbortError") {
+        return;
+      }
+      console.error(err);
+    } finally {
+      if (timelineAbortControllerRef.current?.signal.aborted === false) {
         setTimelineLoading(false);
       }
-    };
-
-    fetchTimeline();
+    }
   }, [id, showType]);
+
+  const onUpdate = async () => {
+    await Promise.all([fetchTicket(), fetchTimeline()]);
+  };
+
+  useEffect(() => {
+    fetchTicket();
+    return () => ticketAbortControllerRef.current?.abort();
+  }, [fetchTicket]);
+
+  useEffect(() => {
+    fetchTimeline();
+    return () => timelineAbortControllerRef.current?.abort();
+  }, [fetchTimeline]);
 
   if (loading) {
     return (
@@ -137,6 +169,7 @@ export default function TicketInfoPage() {
           showType={showType}
           onShowTypeChange={setShowType}
           setTimeline={setTimeline}
+          onUpdate={onUpdate}
         />
       </div>
     </>

--- a/Application/test-utils/render.tsx
+++ b/Application/test-utils/render.tsx
@@ -2,12 +2,17 @@ import { ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
 import { MantineProvider } from "@mantine/core";
 import { theme } from "../app/lib/theme";
+import { UserProvider } from "../app/components/provider/UserContext";
 
 type CustomRenderOptions = Omit<RenderOptions, "wrapper">;
 
 function customRender(ui: ReactElement, options?: CustomRenderOptions) {
   return render(ui, {
-    wrapper: ({ children }) => <MantineProvider theme={theme}>{children}</MantineProvider>,
+    wrapper: ({ children }) => (
+      <MantineProvider theme={theme}>
+        <UserProvider>{children}</UserProvider>
+      </MantineProvider>
+    ),
     ...options,
   });
 }


### PR DESCRIPTION
Refresh on ticket update removed because it causes clunky interaction. Needs to repoll the audit timeline in order to ensure it is up to date on edit. In the future it might make sense to use SSE or maybe websockets to ensure state is always a recent projection of backend state rather than only updating on edit events from the current user.

closes digitalgroundgame/in-house-mgmt#191