### PR TITLE
Filter contacts by multiple tags with any/all mode

### DIFF
--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -288,11 +288,13 @@ export default function ContactsPage() {
                   placeholder="Search tags..."
                   searchable
                   clearable
-                  style={{ minWidth: 200 }}
+                  style={{ minWidth: 200, maxWidth: 450 }}
                   styles={{
                     input: {
                       borderTopLeftRadius: 0,
                       borderBottomLeftRadius: 0,
+                      overflowX: "auto",
+                      flexWrap: "nowrap",
                     },
                   }}
                 />

--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -252,17 +252,16 @@ export default function ContactsPage() {
         {/* Filters */}
         <Paper p="md" withBorder>
           <Stack gap="md">
-            <Group gap="md" align="flex-end">
+            <Group gap="md" align="flex-end" grow>
               <TextInput
                 label="Search"
                 placeholder="Search by name, Discord ID, email, or phone..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 leftSection={<IconSearch size={16} />}
-                style={{ flex: 1 }}
               />
 
-              <Group gap={0} align="flex-end">
+              <Group gap={0} align="flex-end" style={{ flex: 1 }}>
                 <Select
                   label="Tags"
                   data={[
@@ -288,7 +287,7 @@ export default function ContactsPage() {
                   placeholder="Search tags..."
                   searchable
                   clearable
-                  style={{ minWidth: 200, maxWidth: 450 }}
+                  style={{ flex: 1 }}
                   styles={{
                     input: {
                       borderTopLeftRadius: 0,

--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -1,39 +1,31 @@
 "use client";
 
 import {
-  Container,
-  Title,
-  Group,
+  ActionIcon,
   Button,
-  Paper,
-  Text,
-  TextInput,
-  Stack,
+  Container,
+  Group,
   Modal,
   MultiSelect,
-  Select,
-  ActionIcon,
   NumberInput,
+  Paper,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+  Title,
 } from "@mantine/core";
 import { DateInput } from "@mantine/dates";
-import {
-  IconPlus,
-  IconFileUpload,
-  IconSearch,
-  IconChevronLeft,
-  IconChevronRight,
-} from "@tabler/icons-react";
-import { useState, useEffect, Component } from "react";
+import { IconPlus, IconSearch, IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/app/lib/apiClient";
 import { useForm } from "@mantine/form";
 import { TicketBulkCreateModal } from "@/app/components/tickets/TicketBulkCreateModal";
-import ContactTable, {
-  type Contact,
-  type Group as ContactGroup,
-  type Tag,
-} from "@/app/components/ContactTable";
+import ContactTable, { type Contact, type Tag } from "@/app/components/ContactTable";
 import "./page.css";
+
+const MAX_TAG_COUNT = 99999;
 
 export default function ContactsPage() {
   const router = useRouter();
@@ -41,7 +33,6 @@ export default function ContactsPage() {
   const [bulkTicketModalOpen, setBulkTicketModalOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedGroup, setSelectedGroup] = useState<string | null>("all");
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [tagMode, setTagMode] = useState<"any" | "all">("any");
   const [startDate, setStartDate] = useState<string | null>("");
@@ -62,8 +53,8 @@ export default function ContactsPage() {
   const form = useForm({
     initialValues: {
       discord_id: "",
-      full_name: "",
       email: "",
+      full_name: "",
       phone: "",
       tags: [],
     },
@@ -76,102 +67,99 @@ export default function ContactsPage() {
 
   // Fetch groups and tags on component mount
   useEffect(() => {
+    const fetchGroupsAndTags = async () => {
+      try {
+        const tagsData = await apiClient.get<Tag[] | { results: Tag[] }>(
+          `/tags/?page_size=${MAX_TAG_COUNT}`
+        );
+
+        // Handle both array and object responses
+        const tagsArray = Array.isArray(tagsData) ? tagsData : tagsData.results || [];
+        setTags(tagsArray);
+      } catch (error) {
+        console.error("Error fetching groups and tags:", error);
+        setTags([]); // Ensure tags is always an array
+      }
+    };
     fetchGroupsAndTags();
   }, []);
 
-  // Fetch contacts whenever filters change (reset to first page)
+  const fetchContacts = useCallback(
+    async (url?: string) => {
+      try {
+        setLoading(true);
+
+        let fetchUrl = url;
+
+        // If no URL provided, build the initial query
+        if (!fetchUrl) {
+          const params = new URLSearchParams();
+          if (searchQuery) params.append("search", searchQuery);
+          if (minEvents) params.append("min_events", minEvents.toString());
+          if (minTickets) params.append("min_tickets", minTickets.toString());
+          if (maxTickets) params.append("max_tickets", maxTickets.toString());
+          if (maxEvents) params.append("max_tickets", maxEvents.toString());
+          if (startDate) params.append("start_date", startDate);
+          if (endDate) params.append("end_date", endDate);
+
+          if (selectedTagIds.length > 0) {
+            params.append("tag_ids", selectedTagIds.join(","));
+            params.append("tag_mode", tagMode);
+          }
+          fetchUrl = `/contacts/?${params}`;
+        }
+
+        console.log("Fetch URL:", fetchUrl);
+
+        const data = await apiClient.get<{
+          results: Contact[];
+          count: number;
+          next: string | null;
+          previous: string | null;
+        }>(fetchUrl || `/contacts/`);
+
+        console.log("Fetched contacts data:", data);
+        setContacts(data.results);
+        setTotalCount(data.count);
+        setNextUrl(data.next);
+        setPreviousUrl(data.previous);
+      } catch (error) {
+        console.error("Error fetching contacts:", error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [
+      endDate,
+      maxEvents,
+      maxTickets,
+      minEvents,
+      minTickets,
+      searchQuery,
+      selectedTagIds,
+      startDate,
+      tagMode,
+    ]
+  );
+
   useEffect(() => {
     fetchContacts();
-  }, [
-    searchQuery,
-    selectedGroup,
-    selectedTagIds,
-    tagMode,
-    minEvents,
-    minTickets,
-    maxEvents,
-    maxTickets,
-    startDate,
-    endDate,
-  ]);
-
-  const fetchGroupsAndTags = async () => {
-    try {
-      const tagsData = await apiClient.get<Tag[] | { results: Tag[] }>("/tags/");
-      console.log("Tags data:", tagsData);
-
-      // Handle both array and object responses
-      const tagsArray = Array.isArray(tagsData) ? tagsData : tagsData.results || [];
-      setTags(tagsArray);
-    } catch (error) {
-      console.error("Error fetching groups and tags:", error);
-      setTags([]); // Ensure tags is always an array
-    }
-  };
-
-  const fetchContacts = async (url?: string) => {
-    try {
-      setLoading(true);
-
-      let fetchUrl = url;
-
-      // If no URL provided, build the initial query
-      if (!fetchUrl) {
-        const params = new URLSearchParams();
-        if (searchQuery) params.append("search", searchQuery);
-        if (minEvents) params.append("min_events", minEvents.toString());
-        if (minTickets) params.append("min_tickets", minTickets.toString());
-        if (maxTickets) params.append("max_tickets", maxTickets.toString());
-        if (maxEvents) params.append("max_events", maxEvents.toString());
-        if (startDate) params.append("start_date", startDate);
-        if (endDate) params.append("end_date", endDate);
-
-        if (selectedTagIds.length > 0) {
-          params.append("tag_ids", selectedTagIds.join(","));
-          params.append("tag_mode", tagMode);
-        }
-        fetchUrl = `/contacts/?${params}`;
-      }
-
-      console.log("Fetch URL:", fetchUrl);
-
-      const data = await apiClient.get<{
-        results: Contact[];
-        count: number;
-        next: string | null;
-        previous: string | null;
-      }>(fetchUrl || `/contacts/`);
-
-      console.log("Fetched contacts data:", data);
-      setContacts(data.results);
-      setTotalCount(data.count);
-      setNextUrl(data.next);
-      setPreviousUrl(data.previous);
-    } catch (error) {
-      console.error("Error fetching contacts:", error);
-    } finally {
-      setLoading(false);
-    }
-  };
+  }, [fetchContacts]);
 
   const handleReset = () => {
-    setSearchQuery("");
-    setSelectedGroup("all");
-    setSelectedTagIds([]);
-    setTagMode("any");
-    setMaxEvents("");
-    setMinEvents("");
-    setMaxTickets("");
-    setMinTickets("");
-    setStartDate("");
     setEndDate("");
-    fetchContacts();
+    setMaxEvents("");
+    setMaxTickets("");
+    setMinEvents("");
+    setMinTickets("");
+    setSearchQuery("");
+    setSelectedTagIds([]);
+    setStartDate("");
+    setTagMode("any");
   };
 
   const handleRowClick = (contact: Contact) => {
-    // TODO: Navigate to contact detail page or show modal
     router.push(`/contacts/${contact.id}`);
-    console.log("Clicked contact:", contact);
   };
 
   const handleAddContact = () => {
@@ -219,14 +207,12 @@ export default function ContactsPage() {
   const toggleRowSelection = (id: number) => {
     setSelectedRows((prev) => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
-      return next;
+      if (next.has(id)) {
+        next.delete(id);
+        return next;
+      }
+      return next.add(id);
     });
-  };
-
-  const handleUploadCSV = () => {
-    // TODO: Open CSV upload modal
-    console.log("Upload CSV clicked");
   };
 
   return (

--- a/Application/app/contacts/page.tsx
+++ b/Application/app/contacts/page.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   Modal,
   MultiSelect,
+  Select,
   ActionIcon,
   NumberInput,
 } from "@mantine/core";
@@ -27,7 +28,6 @@ import { useRouter } from "next/navigation";
 import { apiClient } from "@/app/lib/apiClient";
 import { useForm } from "@mantine/form";
 import { TicketBulkCreateModal } from "@/app/components/tickets/TicketBulkCreateModal";
-import { SearchSelect, type SearchSelectOption } from "@/app/components/SearchSelect";
 import ContactTable, {
   type Contact,
   type Group as ContactGroup,
@@ -42,7 +42,8 @@ export default function ContactsPage() {
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedGroup, setSelectedGroup] = useState<string | null>("all");
-  const [selectedTag, setSelectedTag] = useState<SearchSelectOption<Tag> | null>(null);
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
+  const [tagMode, setTagMode] = useState<"any" | "all">("any");
   const [startDate, setStartDate] = useState<string | null>("");
   const [endDate, setEndDate] = useState<string | null>("");
   const [minEvents, setMinEvents] = useState<number | string>();
@@ -84,7 +85,8 @@ export default function ContactsPage() {
   }, [
     searchQuery,
     selectedGroup,
-    selectedTag,
+    selectedTagIds,
+    tagMode,
     minEvents,
     minTickets,
     maxEvents,
@@ -124,7 +126,10 @@ export default function ContactsPage() {
         if (startDate) params.append("start_date", startDate);
         if (endDate) params.append("end_date", endDate);
 
-        if (selectedTag) params.append("tag", selectedTag.id.toString());
+        if (selectedTagIds.length > 0) {
+          params.append("tag_ids", selectedTagIds.join(","));
+          params.append("tag_mode", tagMode);
+        }
         fetchUrl = `/contacts/?${params}`;
       }
 
@@ -152,7 +157,8 @@ export default function ContactsPage() {
   const handleReset = () => {
     setSearchQuery("");
     setSelectedGroup("all");
-    setSelectedTag(null);
+    setSelectedTagIds([]);
+    setTagMode("any");
     setMaxEvents("");
     setMinEvents("");
     setMaxTickets("");
@@ -256,19 +262,41 @@ export default function ContactsPage() {
                 style={{ flex: 1 }}
               />
 
-              <SearchSelect<Tag>
-                endpoint="/tags/"
-                label="Tag"
-                placeholder="Search tags..."
-                value={selectedTag}
-                onChange={setSelectedTag}
-                clearable
-                mapResult={(tag) => ({
-                  id: tag.id,
-                  label: tag.name,
-                  raw: tag,
-                })}
-              />
+              <Group gap={0} align="flex-end">
+                <Select
+                  label="Tags"
+                  data={[
+                    { value: "any", label: "Any of" },
+                    { value: "all", label: "All of" },
+                  ]}
+                  value={tagMode}
+                  onChange={(v) => setTagMode((v as "any" | "all") || "any")}
+                  allowDeselect={false}
+                  styles={{
+                    input: {
+                      borderTopRightRadius: 0,
+                      borderBottomRightRadius: 0,
+                      borderRight: "none",
+                      width: 100,
+                    },
+                  }}
+                />
+                <MultiSelect
+                  data={tags.map((t) => ({ value: String(t.id), label: t.name }))}
+                  value={selectedTagIds}
+                  onChange={setSelectedTagIds}
+                  placeholder="Search tags..."
+                  searchable
+                  clearable
+                  style={{ minWidth: 200 }}
+                  styles={{
+                    input: {
+                      borderTopLeftRadius: 0,
+                      borderBottomLeftRadius: 0,
+                    },
+                  }}
+                />
+              </Group>
             </Group>
             <Group>
               <>

--- a/Server/dggcrm/contacts/tests/conftest.py
+++ b/Server/dggcrm/contacts/tests/conftest.py
@@ -76,6 +76,32 @@ def event2(db):
 
 
 @pytest.fixture
+def tag_b(db):
+    return Tag.objects.create(name="vip")
+
+
+@pytest.fixture
+def tag_c(db):
+    return Tag.objects.create(name="donor")
+
+
+@pytest.fixture
+def contact_b(db):
+    return Contact.objects.create(
+        full_name="Bob Example",
+        email="bob@example.com",
+    )
+
+
+@pytest.fixture
+def contact_c(db):
+    return Contact.objects.create(
+        full_name="Carol Example",
+        email="carol@example.com",
+    )
+
+
+@pytest.fixture
 def tag_assignment(db, tag, contact):
     return TagAssignments.objects.create(
         contact=contact,

--- a/Server/dggcrm/contacts/tests/test_contact_tag_filtering.py
+++ b/Server/dggcrm/contacts/tests/test_contact_tag_filtering.py
@@ -1,0 +1,74 @@
+import pytest
+from rest_framework.test import APIClient
+
+from dggcrm.contacts.models import TagAssignments
+
+
+@pytest.fixture
+def client(admin_user):
+    c = APIClient()
+    c.force_authenticate(admin_user)
+    return c
+
+
+@pytest.fixture
+def tagged_contacts(contact, contact_b, contact_c, tag, tag_b, tag_c):
+    """
+    contact  → tag, tag_b
+    contact_b → tag
+    contact_c → tag_b, tag_c
+    """
+    TagAssignments.objects.create(contact=contact, tag=tag)
+    TagAssignments.objects.create(contact=contact, tag=tag_b)
+    TagAssignments.objects.create(contact=contact_b, tag=tag)
+    TagAssignments.objects.create(contact=contact_c, tag=tag_b)
+    TagAssignments.objects.create(contact=contact_c, tag=tag_c)
+    return contact, contact_b, contact_c
+
+
+@pytest.mark.django_db
+class TestContactTagFiltering:
+    def test_no_tag_filter_returns_all(self, client, tagged_contacts):
+        resp = client.get("/api/contacts/")
+        assert resp.status_code == 200
+        assert resp.data["count"] == 3
+
+    def test_single_tag(self, client, tagged_contacts, tag):
+        resp = client.get(f"/api/contacts/?tag_ids={tag.id}")
+        assert resp.status_code == 200
+        ids = {c["id"] for c in resp.data["results"]}
+        contact, contact_b, _ = tagged_contacts
+        assert ids == {contact.id, contact_b.id}
+
+    def test_multiple_tags_any_mode(self, client, tagged_contacts, tag, tag_c):
+        resp = client.get(f"/api/contacts/?tag_ids={tag.id},{tag_c.id}&tag_mode=any")
+        assert resp.status_code == 200
+        ids = {c["id"] for c in resp.data["results"]}
+        contact, contact_b, contact_c = tagged_contacts
+        assert ids == {contact.id, contact_b.id, contact_c.id}
+
+    def test_multiple_tags_all_mode(self, client, tagged_contacts, tag, tag_b):
+        resp = client.get(f"/api/contacts/?tag_ids={tag.id},{tag_b.id}&tag_mode=all")
+        assert resp.status_code == 200
+        ids = {c["id"] for c in resp.data["results"]}
+        contact, _, _ = tagged_contacts
+        assert ids == {contact.id}
+
+    def test_default_mode_is_any(self, client, tagged_contacts, tag, tag_c):
+        resp = client.get(f"/api/contacts/?tag_ids={tag.id},{tag_c.id}")
+        assert resp.status_code == 200
+        ids = {c["id"] for c in resp.data["results"]}
+        contact, contact_b, contact_c = tagged_contacts
+        assert ids == {contact.id, contact_b.id, contact_c.id}
+
+    def test_all_mode_no_overlap_returns_empty(self, client, tagged_contacts, tag, tag_c):
+        resp = client.get(f"/api/contacts/?tag_ids={tag.id},{tag_c.id}&tag_mode=all")
+        assert resp.status_code == 200
+        assert resp.data["count"] == 0
+
+    def test_invalid_tag_ids_ignored(self, client, tagged_contacts, tag):
+        resp = client.get(f"/api/contacts/?tag_ids=abc,{tag.id},,xyz")
+        assert resp.status_code == 200
+        ids = {c["id"] for c in resp.data["results"]}
+        contact, contact_b, _ = tagged_contacts
+        assert ids == {contact.id, contact_b.id}

--- a/Server/dggcrm/contacts/views.py
+++ b/Server/dggcrm/contacts/views.py
@@ -53,7 +53,8 @@ class ContactViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
 
         event_id = self.request.query_params.get("event")
-        tag = self.request.query_params.get("tag")
+        tag_ids_param = self.request.query_params.get("tag_ids")
+        tag_mode = self.request.query_params.get("tag_mode", "any")
         min_tickets = self.request.query_params.get("min_tickets")
         max_tickets = self.request.query_params.get("max_tickets")
         min_events = self.request.query_params.get("min_events")
@@ -67,12 +68,15 @@ class ContactViewSet(viewsets.ModelViewSet):
                 event_participations__event_id=event_id,
             )
 
-        if tag:
-            # allow filtering by tag id OR tag name
-            if tag.isdigit():
-                queryset = queryset.filter(taggings__tag__id=tag)
-            else:
-                queryset = queryset.filter(taggings__tag__name__iexact=tag)
+        if tag_ids_param:
+            tag_ids = [int(v) for v in tag_ids_param.split(",") if v.strip().isdigit()]
+            if tag_ids:
+                if tag_mode == "all":
+                    for tag_id in tag_ids:
+                        queryset = queryset.filter(taggings__tag__id=tag_id)
+                else:
+                    queryset = queryset.filter(taggings__tag__id__in=tag_ids)
+
         date_filter = Q()
         if start_date:
             date_filter &= Q(event_participations__event__ends_at__gte=start_date)


### PR DESCRIPTION
  ## Summary

  - Contacts can now be filtered by multiple tags at once, with a toggle to match **any** (union) or **all** (intersection) of the selected tags
  - Backend accepts `tag_ids` (comma-separated) and `tag_mode` (`any`|`all`) query params, replacing the old single `tag` param
  - Frontend replaces the single-select `SearchSelect` tag picker with a combined `Select` + `MultiSelect` control

  ## Details

  **Backend (`contacts/views.py`):**
  - `tag` param → `tag_ids` (comma-separated ints) + `tag_mode` (`any` default, `all`)
  - "any" mode uses `__in` lookup; "all" mode chains `.filter()` calls to require every tag
  - Non-numeric values in `tag_ids` are silently ignored

  **Frontend (`contacts/page.tsx`):**
  - Removed `SearchSelect` component usage in favor of Mantine `MultiSelect` for tag selection
  - Added a `Select` dropdown for choosing "Any of" / "All of" mode, visually joined to the `MultiSelect`

  ## Test plan

  - [ ] Verify filtering by a single tag returns the correct contacts
  - [ ] Verify "Any of" mode with multiple tags returns the union
  - [ ] Verify "All of" mode with multiple tags returns only contacts with every selected tag
  - [ ] Verify invalid/non-numeric tag IDs are gracefully ignored
  - [ ] Verify clearing tags resets the filter
  - [ ] New backend tests in `test_contact_tag_filtering.py` cover all cases above

Closes #34 