### PR TITLE
Change staging to use dedicated network

### DIFF
--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -14,7 +14,7 @@ services:
       - dggcrm_production_admin_static_files:/app/staticfiles
     labels:
     - traefik.enable=true
-    - traefik.docker.network=coolify
+    - traefik.docker.network=crm-network-staging
     - "traefik.http.routers.inhouse-nginx-staging-http.rule=Host(`housestaging.digitalgroundgame.org`) && PathPrefix(`/`)"
     - traefik.http.routers.inhouse-nginx-staging-http.entryPoints=http
     - "traefik.http.routers.inhouse-nginx-staging-https.rule=Host(`housestaging.digitalgroundgame.org`) && PathPrefix(`/`)"
@@ -23,7 +23,7 @@ services:
     - traefik.http.routers.inhouse-nginx-staging-https.tls.certresolver=letsencrypt
     - traefik.http.services.inhouse-nginx-staging.loadbalancer.server.port=80
     networks:
-      - coolify
+      - crm-network-staging
       - default
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:80/health"]
@@ -107,7 +107,7 @@ services:
     logging:
       driver: journald
     networks:
-      - coolify
+      - crm-network-staging
       - default
 
 
@@ -115,5 +115,5 @@ volumes:
   dggcrm_production_admin_static_files:
 
 networks:
-  coolify:
+  crm-network-staging:
     external: true


### PR DESCRIPTION
I changed the staging resources to be on their own dedicated network, not when the nginx looks up the `server` and `frontend`, the containers available to find will only be in the staging env that nginx is in. I've already made the changes to the staging resources in coolify, the staging app is currently pointing to this branch, we'll need to change it to `dev` before we merge. Here is a very high level of the architecture now.

<img width="3968" height="2272" alt="image" src="https://github.com/user-attachments/assets/fb64370e-6468-4161-924d-b84a60070842" />
