### PR TITLE
Refine sidebar layout

### DIFF
--- a/Application/app/components/Navbar/Navbar.module.css
+++ b/Application/app/components/Navbar/Navbar.module.css
@@ -1,4 +1,5 @@
 .navbar {
+  position: relative;
   min-height: 100vh;
   width: max-content;
   flex: 0 0 auto;
@@ -8,8 +9,39 @@
   background-color: #ffffff;
 }
 
+.navbar[data-collapsed] {
+  padding-inline: var(--mantine-spacing-sm);
+}
+
 .navbarMain {
   flex: 0 0 auto;
+}
+
+.collapseButton {
+  position: absolute;
+  top: var(--mantine-spacing-md);
+  right: -13px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  color: var(--foreground);
+  background: #ffffff;
+  border: 1px solid #dee2e6;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.collapseButton:hover {
+  background-color: var(--mantine-color-gray-1);
+}
+
+.collapseButton:focus-visible {
+  outline: 2px solid var(--mantine-primary-color-filled);
+  outline-offset: 2px;
 }
 
 .footer {
@@ -31,9 +63,18 @@
   cursor: pointer;
 }
 
+.navbar[data-collapsed] .link {
+  justify-content: center;
+  padding-inline: var(--mantine-spacing-xs);
+}
+
 .navLinkRoot,
 .navLinkLabel {
   color: var(--foreground);
+}
+
+.navbar[data-collapsed] .navLinkRoot {
+  justify-content: center;
 }
 
 .link:hover,
@@ -63,10 +104,26 @@
   padding-left: var(--mantine-spacing-sm);
 }
 
+.navbar[data-collapsed] .navLinkChildren {
+  display: none;
+}
+
 .navLinkIcon {
   color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
   width: 25px;
   height: 25px;
+}
+
+.navLinkSection:where([data-position="right"]) {
+  display: flex;
+}
+
+.navbar[data-collapsed] .navLinkSection:where([data-position="right"]) {
+  display: none;
+}
+
+.navbar[data-collapsed] .navLinkSection:where([data-position="left"]) {
+  margin-inline-end: 0;
 }
 
 .checkboxIcon {
@@ -83,4 +140,13 @@
   margin-right: var(--mantine-spacing-sm);
   width: 25px;
   height: 25px;
+}
+
+.navbar[data-collapsed] .linkIcon,
+.navbar[data-collapsed] .checkboxIcon {
+  margin-right: 0;
+}
+
+.navbar[data-collapsed] .linkLabel {
+  display: none;
 }

--- a/Application/app/components/Navbar/Navbar.module.css
+++ b/Application/app/components/Navbar/Navbar.module.css
@@ -1,15 +1,15 @@
 .navbar {
-  height: 100vh;
-  width: 300px;
+  min-height: 100vh;
+  width: max-content;
+  flex: 0 0 auto;
   padding: var(--mantine-spacing-md);
   display: flex;
   flex-direction: column;
-  border-right: 1px solid #dee2e6;
   background-color: #ffffff;
 }
 
 .navbarMain {
-  flex: 1;
+  flex: 0 0 auto;
 }
 
 .header {
@@ -20,44 +20,68 @@
 
 .footer {
   padding-top: var(--mantine-spacing-md);
-  margin-top: var(--mantine-spacing-md);
+  margin-top: calc(var(--mantine-spacing-xl) * 2);
   border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
 }
 
 .link {
   display: flex;
   align-items: center;
+  white-space: nowrap;
   text-decoration: none;
   font-size: var(--mantine-font-size-sm);
-  color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
+  color: var(--foreground);
   padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
   border-radius: var(--mantine-radius-sm);
   font-weight: 500;
+  cursor: pointer;
+}
 
-  @mixin hover {
-    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
-    color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+.navLinkRoot,
+.navLinkLabel {
+  color: var(--foreground);
+}
 
-    .linkIcon {
-      color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-    }
-  }
+.link:hover,
+.navLinkRoot:hover {
+  background-color: var(--mantine-color-gray-light-hover);
+  color: var(--mantine-color-black);
+}
 
-  &[data-active] {
-    &,
-    &:hover {
-      background-color: var(--mantine-color-blue-light);
-      color: var(--mantine-color-blue-light-color);
+.link:hover .linkIcon,
+.navLinkRoot:hover .linkIcon,
+.navLinkRoot:hover .navLinkIcon {
+  color: var(--mantine-color-black);
+}
 
-      .linkIcon {
-        color: var(--mantine-color-blue-light-color);
-      }
-    }
-  }
+.link[data-active],
+.link[data-active]:hover {
+  background-color: var(--mantine-color-blue-light);
+  color: var(--mantine-color-blue-light-color);
+}
+
+.link[data-active] .linkIcon,
+.link[data-active]:hover .linkIcon {
+  color: var(--mantine-color-blue-light-color);
 }
 
 .navLinkChildren {
   padding-left: var(--mantine-spacing-sm);
+}
+
+.navLinkIcon {
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
+  width: 25px;
+  height: 25px;
+}
+
+.checkboxIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: var(--mantine-spacing-sm);
+  width: 25px;
+  height: 25px;
 }
 
 .linkIcon {

--- a/Application/app/components/Navbar/Navbar.module.css
+++ b/Application/app/components/Navbar/Navbar.module.css
@@ -12,12 +12,6 @@
   flex: 0 0 auto;
 }
 
-.header {
-  padding-bottom: var(--mantine-spacing-md);
-  margin-bottom: calc(var(--mantine-spacing-md) * 1.5);
-  border-bottom: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-}
-
 .footer {
   padding-top: var(--mantine-spacing-md);
   margin-top: calc(var(--mantine-spacing-xl) * 2);

--- a/Application/app/components/Navbar/Navbar.module.css
+++ b/Application/app/components/Navbar/Navbar.module.css
@@ -126,15 +126,6 @@
   margin-inline-end: 0;
 }
 
-.checkboxIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-right: var(--mantine-spacing-sm);
-  width: 25px;
-  height: 25px;
-}
-
 .linkIcon {
   color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
   margin-right: var(--mantine-spacing-sm);
@@ -142,8 +133,7 @@
   height: 25px;
 }
 
-.navbar[data-collapsed] .linkIcon,
-.navbar[data-collapsed] .checkboxIcon {
+.navbar[data-collapsed] .linkIcon {
   margin-right: 0;
 }
 

--- a/Application/app/components/Navbar/Navbar.tsx
+++ b/Application/app/components/Navbar/Navbar.tsx
@@ -8,12 +8,11 @@ import {
   IconUsers,
   IconCalendarEvent,
   IconPhone,
-  IconTicketOff,
   IconEyeFilled,
   IconLogout,
   IconBuilding,
 } from "@tabler/icons-react";
-import { Code, Group, NavLink, Switch } from "@mantine/core";
+import { Checkbox, NavLink } from "@mantine/core";
 import classes from "./Navbar.module.css";
 import { useState } from "react";
 import { handleLogout } from "@/app/utils/oauth";
@@ -33,7 +32,7 @@ export default function NavbarSimple() {
   const pathname = usePathname();
 
   const [admin, changeMode] = useState(false);
-  const data = admin ? [...notAdminData, ...adminOnly] : notAdminData;
+  const data = notAdminData;
 
   const showNavbar = pathname !== "/login";
 
@@ -59,17 +58,17 @@ export default function NavbarSimple() {
         ))}
 
         <NavLink
+          className={classes.navLinkRoot}
           label="Internal"
-          leftSection={<IconBuilding size={20} stroke={1.5} className={classes.linkIcon} />}
+          leftSection={<IconBuilding stroke={1.5} className={classes.navLinkIcon} />}
           defaultOpened={isInternalActive}
-          classNames={{ children: classes.navLinkChildren }}
+          classNames={{ children: classes.navLinkChildren, label: classes.navLinkLabel }}
           styles={{
             root: {
               padding: "var(--mantine-spacing-xs) var(--mantine-spacing-sm)",
               borderRadius: "var(--mantine-radius-sm)",
               fontSize: "var(--mantine-font-size-sm)",
               fontWeight: 500,
-              color: "var(--mantine-color-gray-7)",
             },
             label: { padding: 0 },
           }}
@@ -89,9 +88,31 @@ export default function NavbarSimple() {
       </div>
 
       <div className={classes.footer}>
-        <div>
-          <Switch color="red" label="Admin Mode" onChange={() => changeMode(!admin)} />
-        </div>
+        <label className={classes.link}>
+          <span className={classes.checkboxIcon}>
+            <Checkbox
+              aria-label="Admin Mode"
+              checked={admin}
+              color="red"
+              onChange={(event) => changeMode(event.currentTarget.checked)}
+              size="xs"
+            />
+          </span>
+          <span>Admin Mode</span>
+        </label>
+
+        {admin &&
+          adminOnly.map((item) => (
+            <Link
+              className={classes.link}
+              data-active={item.link === pathname || undefined}
+              href={item.link}
+              key={item.label}
+            >
+              <item.icon className={classes.linkIcon} stroke={1.5} />
+              <span>{item.label}</span>
+            </Link>
+          ))}
 
         <Link
           className={classes.link}
@@ -108,9 +129,9 @@ export default function NavbarSimple() {
           <span>Logout</span>
         </a>
       </div>
-      <Group className={classes.header} justify="space-between">
+      {/* <Group className={classes.header} justify="space-between">
         <Code fw={700}>v0.0.0</Code>
-      </Group>
+      </Group> */}
     </nav>
   );
 }

--- a/Application/app/components/Navbar/Navbar.tsx
+++ b/Application/app/components/Navbar/Navbar.tsx
@@ -129,9 +129,6 @@ export default function NavbarSimple() {
           <span>Logout</span>
         </a>
       </div>
-      {/* <Group className={classes.header} justify="space-between">
-        <Code fw={700}>v0.0.0</Code>
-      </Group> */}
     </nav>
   );
 }

--- a/Application/app/components/Navbar/Navbar.tsx
+++ b/Application/app/components/Navbar/Navbar.tsx
@@ -11,6 +11,8 @@ import {
   IconEyeFilled,
   IconLogout,
   IconBuilding,
+  IconChevronLeft,
+  IconChevronRight,
 } from "@tabler/icons-react";
 import { Checkbox, NavLink } from "@mantine/core";
 import classes from "./Navbar.module.css";
@@ -32,6 +34,7 @@ export default function NavbarSimple() {
   const pathname = usePathname();
 
   const [admin, changeMode] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const data = notAdminData;
 
   const showNavbar = pathname !== "/login";
@@ -43,27 +46,49 @@ export default function NavbarSimple() {
   }
 
   return (
-    <nav className={classes.navbar}>
+    <nav className={classes.navbar} data-collapsed={collapsed || undefined}>
+      <button
+        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        className={classes.collapseButton}
+        onClick={() => setCollapsed((value) => !value)}
+        type="button"
+      >
+        {collapsed ? (
+          <IconChevronRight size={16} stroke={1.5} />
+        ) : (
+          <IconChevronLeft size={16} stroke={1.5} />
+        )}
+      </button>
+
       <div className={classes.navbarMain}>
         {data.map((item) => (
           <Link
+            aria-label={item.label}
             className={classes.link}
             data-active={item.link === pathname || undefined}
             href={item.link}
             key={item.label}
           >
             <item.icon className={classes.linkIcon} stroke={1.5} />
-            <span>{item.label}</span>
+            <span className={classes.linkLabel}>{item.label}</span>
           </Link>
         ))}
 
         <NavLink
+          aria-label="Internal"
           className={classes.navLinkRoot}
           label="Internal"
           leftSection={<IconBuilding stroke={1.5} className={classes.navLinkIcon} />}
           defaultOpened={isInternalActive}
-          classNames={{ children: classes.navLinkChildren, label: classes.navLinkLabel }}
+          classNames={{
+            children: classes.navLinkChildren,
+            label: classes.navLinkLabel,
+            section: classes.navLinkSection,
+          }}
           styles={{
+            body: {
+              display: collapsed ? "none" : undefined,
+            },
             root: {
               padding: "var(--mantine-spacing-xs) var(--mantine-spacing-sm)",
               borderRadius: "var(--mantine-radius-sm)",
@@ -75,6 +100,7 @@ export default function NavbarSimple() {
         >
           {internalLinks.map((item) => (
             <Link
+              aria-label={item.label}
               className={classes.link}
               data-active={item.link === pathname || undefined}
               href={item.link}
@@ -98,35 +124,37 @@ export default function NavbarSimple() {
               size="xs"
             />
           </span>
-          <span>Admin Mode</span>
+          <span className={classes.linkLabel}>Admin Mode</span>
         </label>
 
         {admin &&
           adminOnly.map((item) => (
             <Link
+              aria-label={item.label}
               className={classes.link}
               data-active={item.link === pathname || undefined}
               href={item.link}
               key={item.label}
             >
               <item.icon className={classes.linkIcon} stroke={1.5} />
-              <span>{item.label}</span>
+              <span className={classes.linkLabel}>{item.label}</span>
             </Link>
           ))}
 
         <Link
+          aria-label="Profile"
           className={classes.link}
           data-active={"/profile" === pathname || undefined}
           href={"/profile"}
           key={"profile"}
         >
           <IconUser className={classes.linkIcon} stroke={1.5} />
-          <span>Profile</span>
+          <span className={classes.linkLabel}>Profile</span>
         </Link>
 
-        <a href="#" className={classes.link} onClick={handleLogout}>
+        <a aria-label="Logout" href="#" className={classes.link} onClick={handleLogout}>
           <IconLogout className={classes.linkIcon} stroke={1.5} />
-          <span>Logout</span>
+          <span className={classes.linkLabel}>Logout</span>
         </a>
       </div>
     </nav>

--- a/Application/app/components/Navbar/Navbar.tsx
+++ b/Application/app/components/Navbar/Navbar.tsx
@@ -14,10 +14,11 @@ import {
   IconChevronLeft,
   IconChevronRight,
 } from "@tabler/icons-react";
-import { Checkbox, NavLink } from "@mantine/core";
+import { NavLink } from "@mantine/core";
 import classes from "./Navbar.module.css";
 import { useState } from "react";
 import { handleLogout } from "@/app/utils/oauth";
+import { useUser } from "@/app/components/provider/UserContext";
 
 const notAdminData = [
   { link: "/home", label: "Home", icon: IconHome },
@@ -32,10 +33,11 @@ const adminOnly = [{ link: "/management", label: "Management", icon: IconEyeFill
 
 export default function NavbarSimple() {
   const pathname = usePathname();
+  const { user } = useUser();
 
-  const [admin, changeMode] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const data = notAdminData;
+  const isAdmin = user?.groups.includes("ADMIN") ?? false;
 
   const showNavbar = pathname !== "/login";
 
@@ -114,20 +116,7 @@ export default function NavbarSimple() {
       </div>
 
       <div className={classes.footer}>
-        <label className={classes.link}>
-          <span className={classes.checkboxIcon}>
-            <Checkbox
-              aria-label="Admin Mode"
-              checked={admin}
-              color="red"
-              onChange={(event) => changeMode(event.currentTarget.checked)}
-              size="xs"
-            />
-          </span>
-          <span className={classes.linkLabel}>Admin Mode</span>
-        </label>
-
-        {admin &&
+        {isAdmin &&
           adminOnly.map((item) => (
             <Link
               aria-label={item.label}

--- a/Application/app/layout.tsx
+++ b/Application/app/layout.tsx
@@ -44,9 +44,17 @@ export default function RootLayout({
           <MantineProvider theme={theme}>
             <Notifications position="top-center" />
             <TimezoneProvider>
-              <div style={{ display: "flex" }}>
+              <div
+                style={{
+                  alignItems: "stretch",
+                  display: "flex",
+                  minHeight: "100vh",
+                }}
+              >
                 <NavbarSimple />
-                <main style={{ flex: 1, padding: "20px" }}>{children}</main>
+                <main style={{ borderLeft: "1px solid #dee2e6", flex: 1, padding: "20px" }}>
+                  {children}
+                </main>
               </div>
             </TimezoneProvider>
           </MantineProvider>


### PR DESCRIPTION

https://github.com/user-attachments/assets/7065cdfe-1a20-41ae-9735-1edb842eab9e


## Summary

- Refine the sidebar so it shrink-wraps its contents and uses consistent link colors, hover states, and icon/text alignment.
- Add collapse mode that hides labels and shows icons. 
- Make admin management tab only show for admins.
- Move the sidebar divider to the content column so it extends with full page height.
- Delete the version badge. (are we using / updating versions?)

## Validation

- Manual visual and behavioral checks.
