### PR TITLE
Validate event finalization attendance

### DIFF
--- a/Application/app/components/pagination/PaginatedTable.tsx
+++ b/Application/app/components/pagination/PaginatedTable.tsx
@@ -53,11 +53,19 @@ export interface PaginatedTableProps<T> {
    * @returns
    */
   onRowClick?: (ele: T) => void;
+  /**
+   * optional row background resolver. Takes precedence over selected row color.
+   */
+  getRowBg?: (ele: T) => string | undefined;
 }
 
 function toggleOne(prev: Set<number>, id: number) {
   const next = new Set(prev);
-  next.has(id) ? next.delete(id) : next.add(id);
+  if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
   return next;
 }
 
@@ -90,6 +98,7 @@ export default function PaginatedTable<T>(props: PaginatedTableProps<T>) {
     showTitle,
     loading,
     noDataText,
+    getRowBg,
   } = props;
 
   if (useCheckboxes && (!selected || !onSelectionChange || !keyFn)) {
@@ -142,13 +151,14 @@ export default function PaginatedTable<T>(props: PaginatedTableProps<T>) {
           ) : (
             data.map((ele, index) => {
               const id = keyFn?.(ele);
+              const customRowBg = getRowBg?.(ele);
 
               return (
                 <Table.Tr
                   bg={
                     id !== undefined && selected!.has(id)
                       ? "var(--mantine-color-blue-light)"
-                      : undefined
+                      : customRowBg
                   }
                   style={{ cursor: "pointer" }}
                   key={id ?? `row-${index}`}

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -42,11 +42,12 @@ import {
   Textarea,
   ActionIcon,
   Tooltip,
+  Alert,
 } from "@mantine/core";
 import { IconPencil, IconSearch } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import getCookie from "@/app/utils/cookie";
 import { formatBackendProvidedDateTime } from "@/app/utils/datetime";
@@ -59,6 +60,15 @@ const EVENT_PARTICIPATION_STATUSES = [
   "NO_SHOW",
 ] as const;
 type EventParticipationStatus = (typeof EVENT_PARTICIPATION_STATUSES)[number];
+const INVALID_FINAL_ATTENDANCE_STATUSES = new Set<EventParticipationStatus>([
+  "UNKNOWN",
+  "MAYBE",
+  "COMMITTED",
+]);
+
+function hasInvalidFinalAttendanceStatus(status: string) {
+  return INVALID_FINAL_ATTENDANCE_STATUSES.has(status as EventParticipationStatus);
+}
 
 interface EventEditFormValues {
   name: string;
@@ -95,6 +105,7 @@ function EventViewMain({ event }: { event: Event }) {
   const [currentEvent, setCurrentEvent] = useState(event);
   const [isEditing, setIsEditing] = useState(false);
   const [isSavingEventEdits, setIsSavingEventEdits] = useState(false);
+  const [attendanceValidationError, setAttendanceValidationError] = useState<string | null>(null);
   const form = useForm<EventEditFormValues>({
     initialValues: getEventFormValues(event),
   });
@@ -122,6 +133,7 @@ function EventViewMain({ event }: { event: Event }) {
       const values = getEventFormValues(updated);
       form.setValues(values);
       form.resetDirty(values);
+      setAttendanceValidationError(null);
 
       notifications.show({
         title: "Event updated",
@@ -130,12 +142,9 @@ function EventViewMain({ event }: { event: Event }) {
       });
       setIsEditing(false);
     } catch (error) {
-      console.error(error);
-      notifications.show({
-        title: "Save failed",
-        message: "Could not update the event details.",
-        color: "red",
-      });
+      setAttendanceValidationError(
+        error instanceof Error ? error.message : "Could not update the event details."
+      );
     } finally {
       setIsSavingEventEdits(false);
     }
@@ -145,6 +154,7 @@ function EventViewMain({ event }: { event: Event }) {
     const values = getEventFormValues(currentEvent);
     form.setValues(values);
     form.resetDirty(values);
+    setAttendanceValidationError(null);
     setIsEditing(false);
   };
 
@@ -180,6 +190,17 @@ function EventViewMain({ event }: { event: Event }) {
               </>
             )}
           </Group>
+        )}
+        {attendanceValidationError && (
+          <Alert
+            color="red"
+            mb="md"
+            withCloseButton
+            onClose={() => setAttendanceValidationError(null)}
+          >
+            {attendanceValidationError} Participants with unresolved attendance statuses are
+            highlighted below.
+          </Alert>
         )}
         <EventSummaryCard event={currentEvent} isEditing={isEditing} form={form} />
         <Tabs defaultValue="participants" mt="md">
@@ -902,6 +923,16 @@ function EventViewContactTable({ event }: { event: Event }) {
   };
 
   const selectedData = data?.results.filter((participation) => selected.has(participation.id));
+  const sortedParticipations = useMemo(() => {
+    return [...(data?.results ?? [])].sort((a, b) => {
+      const aInvalid = hasInvalidFinalAttendanceStatus(a.status);
+      const bInvalid = hasInvalidFinalAttendanceStatus(b.status);
+
+      if (aInvalid === bInvalid) return 0;
+      return aInvalid ? -1 : 1;
+    });
+  }, [data?.results]);
+
   return (
     <>
       {opened && (
@@ -965,7 +996,7 @@ function EventViewContactTable({ event }: { event: Event }) {
             <PaginatedTable
               title="Participants"
               showTitle={true}
-              data={data.results}
+              data={sortedParticipations}
               onRowClick={(ep: EventParticipation) => router.push(`/contacts/${ep.contact.id}`)}
               columns={["Name", "Contact", "Status"]}
               transforms={[
@@ -992,6 +1023,11 @@ function EventViewContactTable({ event }: { event: Event }) {
               onSelectionChange={setSelected}
               selected={selected}
               keyFn={(ep: EventParticipation) => ep.id}
+              getRowBg={(ep: EventParticipation) =>
+                hasInvalidFinalAttendanceStatus(ep.status)
+                  ? "var(--mantine-color-red-light)"
+                  : undefined
+              }
             />
           )}
           {data && (

--- a/Application/app/events/[id]/EventView.tsx
+++ b/Application/app/events/[id]/EventView.tsx
@@ -46,7 +46,7 @@ import {
 } from "@mantine/core";
 import { IconPencil, IconSearch } from "@tabler/icons-react";
 import { notifications } from "@mantine/notifications";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import getCookie from "@/app/utils/cookie";
@@ -60,11 +60,16 @@ const EVENT_PARTICIPATION_STATUSES = [
   "NO_SHOW",
 ] as const;
 type EventParticipationStatus = (typeof EVENT_PARTICIPATION_STATUSES)[number];
+const FINAL_EVENT_STATUSES = new Set(["completed", "canceled"]);
 const INVALID_FINAL_ATTENDANCE_STATUSES = new Set<EventParticipationStatus>([
   "UNKNOWN",
   "MAYBE",
   "COMMITTED",
 ]);
+
+function isFinalEventStatus(status: string) {
+  return FINAL_EVENT_STATUSES.has(status);
+}
 
 function hasInvalidFinalAttendanceStatus(status: string) {
   return INVALID_FINAL_ATTENDANCE_STATUSES.has(status as EventParticipationStatus);
@@ -416,12 +421,14 @@ function EventViewMetadata({
 }
 
 function AddParticipantModal({
+  event,
   selected,
   opened,
   close,
   refresh,
   mode,
 }: {
+  event: Event;
   selected?: EventParticipation[];
   opened: boolean;
   close: () => void;
@@ -435,9 +442,11 @@ function AddParticipantModal({
   const [removedContactIds, setRemovedContactIds] = useState<Set<number>>(new Set());
   const [eventStatus, setEventStatus] = useState<EventParticipationStatus>();
   const [submitting, setSubmitting] = useState(false);
-  const eventId = usePathname().split("/").pop();
   const apiParams = new URLSearchParams();
   if (contactSearchQuery) apiParams.append("search", contactSearchQuery);
+  const participationStatusOptions = isFinalEventStatus(event.event_status)
+    ? EVENT_PARTICIPATION_STATUSES.filter((status) => !hasInvalidFinalAttendanceStatus(status))
+    : EVENT_PARTICIPATION_STATUSES;
 
   const contactToParticipationMap = new Map<number, number>();
   if (mode === "modify" && selected) {
@@ -486,7 +495,7 @@ function AddParticipantModal({
         await Promise.all(
           Array.from(selectedContacts).map((c) =>
             createMutate({
-              event_id: Number.parseInt(eventId!),
+              event_id: event.id,
               status: eventStatus,
               contact_id: c.id,
             })
@@ -596,7 +605,7 @@ function AddParticipantModal({
           </Combobox>
         )}
         <Select
-          data={EVENT_PARTICIPATION_STATUSES}
+          data={participationStatusOptions}
           label="Participation Status"
           onChange={(s) => setEventStatus(s as EventParticipationStatus)}
           placeholder="Participation Status"
@@ -937,6 +946,7 @@ function EventViewContactTable({ event }: { event: Event }) {
     <>
       {opened && (
         <AddParticipantModal
+          event={event}
           selected={modalMode === "add" ? undefined : selectedData}
           opened={opened}
           close={close}

--- a/Application/app/lib/apiClient.ts
+++ b/Application/app/lib/apiClient.ts
@@ -1,5 +1,17 @@
 import getCookie from "@/app/utils/cookie";
 
+export class ApiError extends Error {
+  status: number;
+  body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   const isFullUrl = path.startsWith("http://") || path.startsWith("https://");
   const url = isFullUrl ? path : `/api${path}`;
@@ -14,7 +26,6 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => null);
-    console.error("API error body:", errorBody);
     let detail = errorBody?.detail;
     if (Array.isArray(detail)) {
       detail = detail[0];
@@ -22,7 +33,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
       detail = JSON.stringify(detail);
     }
     detail = detail || `API error: ${res.status}`;
-    throw new Error(detail);
+    throw new ApiError(detail, res.status, errorBody);
   }
   if (res.status === 204) return undefined as T;
   return res.json();

--- a/Server/dggcrm/events/serializers.py
+++ b/Server/dggcrm/events/serializers.py
@@ -8,6 +8,13 @@ from .permissions import can_change_event
 
 User = get_user_model()
 
+FINAL_EVENT_STATUSES = {EventStatus.COMPLETED, EventStatus.CANCELED}
+INVALID_FINAL_ATTENDANCE_STATUSES = {
+    CommitmentStatus.UNKNOWN,
+    CommitmentStatus.MAYBE,
+    CommitmentStatus.COMMITTED,
+}
+
 
 class EventSerializer(serializers.ModelSerializer):
     status_display = serializers.CharField(source="get_event_status_display", read_only=True)
@@ -47,15 +54,10 @@ class EventSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         event_status = attrs.get("event_status")
 
-        if event_status in {EventStatus.COMPLETED, EventStatus.CANCELED}:
-            invalid_statuses = [
-                CommitmentStatus.UNKNOWN,
-                CommitmentStatus.MAYBE,
-                CommitmentStatus.COMMITTED,
-            ]
+        if event_status in FINAL_EVENT_STATUSES:
             invalid_participations = EventParticipation.objects.filter(
                 event=self.instance,
-                status__in=invalid_statuses,
+                status__in=INVALID_FINAL_ATTENDANCE_STATUSES,
             ).values_list("id", flat=True)
             invalid_participation_ids = list(invalid_participations)
 
@@ -94,6 +96,19 @@ class EventParticipationSerializer(serializers.ModelSerializer):
         fields = "__all__"
         read_only_fields = ["id", "created_at", "modified_at", "status_display"]
         validators = []
+
+    def validate(self, attrs):
+        status = attrs.get("status")
+        event = attrs.get("event") or (self.instance.event if self.instance else None)
+
+        if event and event.event_status in FINAL_EVENT_STATUSES and status in INVALID_FINAL_ATTENDANCE_STATUSES:
+            raise serializers.ValidationError(
+                {
+                    "detail": "Attendance status cannot be unresolved for a completed or canceled event.",
+                }
+            )
+
+        return attrs
 
 
 class UsersInEventSerializer(serializers.ModelSerializer):

--- a/Server/dggcrm/events/serializers.py
+++ b/Server/dggcrm/events/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 
 from ..contacts.models import Contact
 from ..contacts.serializers import ContactSerializer
-from .models import CommitmentStatus, Event, EventParticipation, UsersInEvent
+from .models import CommitmentStatus, Event, EventParticipation, EventStatus, UsersInEvent
 from .permissions import can_change_event
 
 User = get_user_model()
@@ -43,6 +43,31 @@ class EventSerializer(serializers.ModelSerializer):
                 "event_status",
             }
         )
+
+    def validate(self, attrs):
+        event_status = attrs.get("event_status")
+
+        if event_status in {EventStatus.COMPLETED, EventStatus.CANCELED}:
+            invalid_statuses = [
+                CommitmentStatus.UNKNOWN,
+                CommitmentStatus.MAYBE,
+                CommitmentStatus.COMMITTED,
+            ]
+            invalid_participations = EventParticipation.objects.filter(
+                event=self.instance,
+                status__in=invalid_statuses,
+            ).values_list("id", flat=True)
+            invalid_participation_ids = list(invalid_participations)
+
+            if invalid_participation_ids:
+                raise serializers.ValidationError(
+                    {
+                        "detail": "Attendance statuses must be resolved before an event can be completed or canceled.",
+                        "invalid_participation_ids": invalid_participation_ids,
+                    }
+                )
+
+        return attrs
 
 
 class EventParticipationSerializer(serializers.ModelSerializer):

--- a/Server/dggcrm/events/tests/test_views.py
+++ b/Server/dggcrm/events/tests/test_views.py
@@ -67,6 +67,120 @@ class TestParticipationCreate:
         scheduled_participation.refresh_from_db()
         assert scheduled_participation.status == CommitmentStatus.ATTENDED
 
+    @pytest.mark.parametrize("final_status", [EventStatus.COMPLETED, EventStatus.CANCELED])
+    @pytest.mark.parametrize(
+        "invalid_status",
+        [
+            CommitmentStatus.UNKNOWN,
+            CommitmentStatus.MAYBE,
+            CommitmentStatus.COMMITTED,
+        ],
+    )
+    def test_create_rejects_unresolved_status_for_final_event(
+        self,
+        admin_user,
+        scheduled_event,
+        contact,
+        final_status,
+        invalid_status,
+    ):
+        scheduled_event.event_status = final_status
+        scheduled_event.save()
+        self.client.force_authenticate(user=admin_user)
+
+        response = self.client.post(
+            ENDPOINT,
+            {"event_id": scheduled_event.id, "contact_id": contact.id, "status": invalid_status},
+        )
+
+        assert response.status_code == 400
+        assert "Attendance status cannot be unresolved" in response.data["detail"][0]
+        assert not EventParticipation.objects.filter(event=scheduled_event, contact=contact).exists()
+
+    @pytest.mark.parametrize(
+        "valid_status",
+        [
+            CommitmentStatus.REJECTED,
+            CommitmentStatus.ATTENDED,
+            CommitmentStatus.NO_SHOW,
+        ],
+    )
+    def test_create_allows_resolved_status_for_final_event(
+        self,
+        admin_user,
+        scheduled_event,
+        contact,
+        valid_status,
+    ):
+        scheduled_event.event_status = EventStatus.COMPLETED
+        scheduled_event.save()
+        self.client.force_authenticate(user=admin_user)
+
+        response = self.client.post(
+            ENDPOINT,
+            {"event_id": scheduled_event.id, "contact_id": contact.id, "status": valid_status},
+        )
+
+        assert response.status_code == 201
+        assert EventParticipation.objects.filter(
+            event=scheduled_event,
+            contact=contact,
+            status=valid_status,
+        ).exists()
+
+    @pytest.mark.parametrize(
+        "invalid_status",
+        [
+            CommitmentStatus.UNKNOWN,
+            CommitmentStatus.MAYBE,
+            CommitmentStatus.COMMITTED,
+        ],
+    )
+    def test_patch_rejects_unresolved_status_for_final_event(
+        self,
+        admin_user,
+        completed_participation,
+        invalid_status,
+    ):
+        completed_participation.status = CommitmentStatus.ATTENDED
+        completed_participation.save()
+        self.client.force_authenticate(user=admin_user)
+
+        response = self.client.patch(
+            f"{ENDPOINT}{completed_participation.id}/",
+            {"status": invalid_status},
+        )
+
+        assert response.status_code == 400
+        assert "Attendance status cannot be unresolved" in response.data["detail"][0]
+        completed_participation.refresh_from_db()
+        assert completed_participation.status == CommitmentStatus.ATTENDED
+
+    @pytest.mark.parametrize(
+        "valid_status",
+        [
+            CommitmentStatus.REJECTED,
+            CommitmentStatus.ATTENDED,
+            CommitmentStatus.NO_SHOW,
+        ],
+    )
+    def test_patch_allows_resolved_status_for_final_event(
+        self,
+        admin_user,
+        completed_participation,
+        valid_status,
+    ):
+        self.client.force_authenticate(user=admin_user)
+
+        response = self.client.patch(
+            f"{ENDPOINT}{completed_participation.id}/",
+            {"status": valid_status},
+        )
+
+        assert response.status_code == 200
+        completed_participation.refresh_from_db()
+        assert completed_participation.status == valid_status
+
 
 @pytest.mark.django_db
 class TestEventEditWorkflow:

--- a/Server/dggcrm/events/tests/test_views.py
+++ b/Server/dggcrm/events/tests/test_views.py
@@ -141,6 +141,66 @@ class TestEventEditWorkflow:
         assert scheduled_event.event_status == EventStatus.COMPLETED
         assert response.data["event_status"] == EventStatus.COMPLETED
 
+    @pytest.mark.parametrize("final_status", [EventStatus.COMPLETED, EventStatus.CANCELED])
+    @pytest.mark.parametrize(
+        "invalid_status",
+        [
+            CommitmentStatus.UNKNOWN,
+            CommitmentStatus.MAYBE,
+            CommitmentStatus.COMMITTED,
+        ],
+    )
+    def test_patch_final_status_rejected_with_unresolved_attendance(
+        self,
+        admin_user,
+        scheduled_event,
+        scheduled_participation,
+        final_status,
+        invalid_status,
+    ):
+        scheduled_participation.status = invalid_status
+        scheduled_participation.save()
+        self.client.force_authenticate(user=admin_user)
+
+        response = self.client.patch(
+            f"/api/events/{scheduled_event.id}/",
+            {"event_status": final_status},
+        )
+
+        assert response.status_code == 400
+        assert "Attendance statuses must be resolved" in response.data["detail"][0]
+        assert response.data["invalid_participation_ids"] == [str(scheduled_participation.id)]
+        scheduled_event.refresh_from_db()
+        assert scheduled_event.event_status == EventStatus.SCHEDULED
+
+    @pytest.mark.parametrize(
+        "valid_status",
+        [
+            CommitmentStatus.REJECTED,
+            CommitmentStatus.ATTENDED,
+            CommitmentStatus.NO_SHOW,
+        ],
+    )
+    def test_patch_final_status_allowed_with_resolved_attendance(
+        self,
+        admin_user,
+        scheduled_event,
+        scheduled_participation,
+        valid_status,
+    ):
+        scheduled_participation.status = valid_status
+        scheduled_participation.save()
+        self.client.force_authenticate(user=admin_user)
+
+        response = self.client.patch(
+            f"/api/events/{scheduled_event.id}/",
+            {"event_status": EventStatus.COMPLETED},
+        )
+
+        assert response.status_code == 200
+        scheduled_event.refresh_from_db()
+        assert scheduled_event.event_status == EventStatus.COMPLETED
+
     def test_patch_denied_without_edit_permission(
         self,
         regular_user,


### PR DESCRIPTION


https://github.com/user-attachments/assets/40479a26-d388-4abb-82f8-52befe05d5cf


## Summary
- Block event finalization when attendance statuses are unresolved.
- Block participation writes that would make attendance unresolved on already-finalized events.
- Show an inline event-page error when finalization validation fails.
- Highlight unresolved participant rows and sort them before resolved rows.

## Details
Final event states are `completed` and `canceled`.

Events cannot be saved into a final state while any participant is `UNKNOWN`, `MAYBE`, or `COMMITTED`. Once an event is already final, participation status changes cannot set attendance back to those unresolved statuses. Resolved statuses (`REJECTED`, `ATTENDED`, `NO_SHOW`) remain allowed so existing invalid finalized-event data can be corrected.

The event participants table always highlights unresolved attendance rows and sorts them first. For finalized events, the participant status modal only offers resolved attendance statuses.

## Validation
- Manual tests
- Automated tests

Closes #100 