### PR TITLE
Persist ticket list filter/sort/pagination state in URL (#270)

### DIFF
--- a/Application/app/components/tickets/TicketTable.tsx
+++ b/Application/app/components/tickets/TicketTable.tsx
@@ -5,18 +5,17 @@ import { IconChevronUp, IconChevronDown, IconSelector } from "@tabler/icons-reac
 import { useRouter } from "next/navigation";
 import { useUser } from "@/app/components/provider/UserContext";
 import { Ticket } from "./ticket-utils";
+import { type TicketSort } from "./ticket-list";
 import { RelativeTime } from "@/app/components/datetime";
 
-export type SortDirection = "asc" | "desc" | null;
-export type SortField = "id" | "title" | "assigned_to_id" | "created_at" | null;
+type SortableField = "id" | "title" | "assigned_to_id" | "created_at";
 
 interface TicketTableProps {
   tickets: Ticket[];
   loading?: boolean;
   showTitle?: boolean;
-  sortField?: SortField;
-  sortDirection?: SortDirection;
-  onSort?: (field: SortField, direction: SortDirection) => void;
+  sort?: TicketSort;
+  onSortChange?: (sort: TicketSort | undefined) => void;
   onStatusToggle?: () => void;
   filterParams?: string;
 }
@@ -48,41 +47,43 @@ export const getStatusColor = (status: string) => {
   }
 };
 
+function decodeSort(sort: TicketSort | undefined): {
+  field: SortableField | null;
+  direction: "asc" | "desc" | null;
+} {
+  if (!sort) return { field: null, direction: null };
+  const desc = sort.startsWith("-");
+  const field = (desc ? sort.slice(1) : sort) as SortableField;
+  return { field, direction: desc ? "desc" : "asc" };
+}
+
+function nextSort(current: TicketSort | undefined, field: SortableField): TicketSort | undefined {
+  const { field: curField, direction } = decodeSort(current);
+  if (curField !== field) return field as TicketSort; // new field → asc
+  if (direction === "asc") return `-${field}` as TicketSort; // asc → desc
+  return undefined; // desc → off
+}
+
 export default function TicketTable({
-  tickets: tickets,
+  tickets,
   loading = false,
   showTitle = true,
-  sortField = null,
-  sortDirection = null,
-  onSort,
+  sort,
+  onSortChange,
   onStatusToggle,
   filterParams,
 }: TicketTableProps) {
   const router = useRouter();
   const { user } = useUser();
 
-  const handleSort = (field: SortField) => {
-    if (!onSort) return;
+  const { field: sortField, direction: sortDirection } = decodeSort(sort);
 
-    let newDirection: SortDirection;
-    if (sortField !== field) {
-      // New field, start with ascending
-      newDirection = "asc";
-    } else if (sortDirection === "asc") {
-      // Currently ascending, switch to descending
-      newDirection = "desc";
-    } else if (sortDirection === "desc") {
-      // Currently descending, turn off
-      newDirection = null;
-    } else {
-      // Currently off, start with ascending
-      newDirection = "asc";
-    }
-
-    onSort(newDirection ? field : null, newDirection);
+  const handleSort = (field: SortableField) => {
+    if (!onSortChange) return;
+    onSortChange(nextSort(sort, field));
   };
 
-  const getSortIcon = (field: SortField) => {
+  const getSortIcon = (field: SortableField) => {
     if (sortField !== field) {
       return <IconSelector size={14} style={{ opacity: 0.5 }} />;
     }

--- a/Application/app/components/tickets/TicketTemplateView.tsx
+++ b/Application/app/components/tickets/TicketTemplateView.tsx
@@ -14,15 +14,20 @@ import {
   ActionIcon,
 } from "@mantine/core";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useEffect, useState } from "react";
 import { apiClient } from "@/app/lib/apiClient";
-import TicketTable, {
-  type SortField,
-  type SortDirection,
-} from "@/app/components/tickets/TicketTable";
+import TicketTable from "@/app/components/tickets/TicketTable";
 import { useUser } from "@/app/components/provider/UserContext";
 import { SearchSelect, type SearchSelectOption } from "@/app/components/SearchSelect";
 import { type Ticket } from "@/app/components/tickets/ticket-utils";
+import { makePaginatedResponse, useListQuery } from "@/app/lib/list";
+import {
+  fetchTicketsList,
+  presentTicket,
+  ticketListQuerySchema,
+  type TicketSort,
+  type TicketListState,
+} from "@/app/components/tickets/ticket-list";
 
 interface UserResult {
   id: number;
@@ -38,7 +43,6 @@ interface EventResult {
 
 const openStatusValues = ["OPEN", "TODO", "IN_PROGRESS", "BLOCKED"];
 const closedStatusValues = ["COMPLETED", "CANCELED"];
-const defaultExcluded = ["COMPLETED", "CANCELED"];
 
 const statusBadges = [
   { value: "OPEN", label: "Open" },
@@ -57,130 +61,65 @@ export default function TicketTemplateView({
   ticketTypes,
 }: TicketTemplateViewProps) {
   const { user } = useUser();
-
-  // When there's only one type it's always applied as a fixed filter
   const fixedType = ticketTypes.length === 1 ? ticketTypes[0].value : null;
 
-  const [tickets, setTickets] = useState<Ticket[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [excludedStatuses, setExcludedStatuses] = useState<string[]>(defaultExcluded);
-  const [priorities, setPriorities] = useState<{ value: string; label: string }[]>([]);
-  const [priority, setPriority] = useState<string | null>(null);
-  const [ticketType, setTicketType] = useState<string | null>(null);
-  const [assignee, setAssignee] = useState<SearchSelectOption<UserResult> | null>(null);
-  const [assignedToMe, setAssignedToMe] = useState(false);
-  const [event, setEvent] = useState<SearchSelectOption<EventResult> | null>(null);
-  const [nextUrl, setNextUrl] = useState<string | null>(null);
-  const [previousUrl, setPreviousUrl] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState(0);
-  const [sortField, setSortField] = useState<SortField>(null);
-  const [sortDirection, setSortDirection] = useState<SortDirection>(null);
-  const didInitialFetch = useRef(false);
-
-  const fetchPriorities = useCallback(async () => {
-    try {
-      const data = await apiClient.get<{ value: number; label: string }[]>("/ticket-priorities");
-      setPriorities(data.map((p) => ({ value: String(p.value), label: p.label })));
-    } catch (error) {
-      console.error("Error fetching priorities:", error);
-    }
-  }, []);
-
-  const fetchTickets = useCallback(
-    async (
-      url?: string,
-      overrides?: {
-        priority?: string | null;
-        ticketType?: string | null;
-        assignee?: SearchSelectOption<UserResult> | null;
-        event?: SearchSelectOption<EventResult> | null;
-        sortField?: SortField;
-        sortDirection?: SortDirection;
-        excludedStatuses?: string[];
-      }
-    ) => {
-      try {
-        setLoading(true);
-        let fetchPath = url || "/tickets";
-
-        if (!url) {
-          const params = new URLSearchParams();
-
-          const effectivePriority =
-            overrides?.priority !== undefined ? overrides.priority : priority;
-          const effectiveType =
-            overrides?.ticketType !== undefined ? overrides.ticketType : ticketType;
-          const effectiveSortField =
-            overrides?.sortField !== undefined ? overrides.sortField : sortField;
-          const effectiveSortDirection =
-            overrides?.sortDirection !== undefined ? overrides.sortDirection : sortDirection;
-          const effectiveAssignee =
-            overrides?.assignee !== undefined ? overrides.assignee : assignee;
-          const effectiveEvent = overrides?.event !== undefined ? overrides.event : event;
-          const effectiveExcluded =
-            overrides?.excludedStatuses !== undefined
-              ? overrides.excludedStatuses
-              : excludedStatuses;
-
-          // Fixed type takes priority; user-selected type only applies when there are multiple options
-          if (fixedType) {
-            params.append("type", fixedType);
-          } else if (effectiveType) {
-            params.append("type", effectiveType);
-          }
-          if (effectiveAssignee) params.append("assigned_to", String(effectiveAssignee.id));
-          if (effectiveEvent) params.append("event", String(effectiveEvent.id));
-          if (effectivePriority != null) params.append("priority", effectivePriority);
-          if (effectiveSortField && effectiveSortDirection) {
-            params.append(
-              "ordering",
-              effectiveSortDirection === "desc" ? `-${effectiveSortField}` : effectiveSortField
-            );
-          }
-          if (effectiveExcluded.length > 0)
-            params.append("exclude_status", effectiveExcluded.join(","));
-
-          if (params.toString()) fetchPath = `/tickets?${params.toString()}`;
-        }
-
-        const data = await apiClient.get<{
-          results: Ticket[];
-          count: number;
-          next: string | null;
-          previous: string | null;
-        }>(fetchPath);
-        setTickets(data.results || []);
-        setTotalCount(data.count);
-        setNextUrl(data.next);
-        setPreviousUrl(data.previous);
-      } catch (error) {
-        console.error("Error fetching tickets:", error);
-      } finally {
-        setLoading(false);
-      }
+  const { state, setParam, setMany, reset, data, loading, queryString } = useListQuery({
+    schema: ticketListQuerySchema,
+    fetcher: async (s: TicketListState) => {
+      const effective: TicketListState = fixedType
+        ? { ...s, ticketType: fixedType as TicketListState["ticketType"] }
+        : s;
+      const service = await fetchTicketsList(effective);
+      return makePaginatedResponse(service, {
+        page: s.page,
+        perPage: s.perPage,
+        present: presentTicket,
+      });
     },
-    [assignee, event, excludedStatuses, fixedType, priority, sortDirection, sortField, ticketType]
-  );
+  });
+
+  const [priorities, setPriorities] = useState<{ value: string; label: string }[]>([]);
+
+  // SearchSelect needs the option's label to display; URL only carries the ID.
+  // Cache the last-clicked option locally so refresh-by-URL can still drive the filter
+  // (the input shows empty until the user re-opens it — acceptable v1 trade-off).
+  const [assigneeOption, setAssigneeOption] = useState<SearchSelectOption<UserResult> | null>(null);
+  const [eventOption, setEventOption] = useState<SearchSelectOption<EventResult> | null>(null);
 
   useEffect(() => {
-    if (didInitialFetch.current) return;
-    didInitialFetch.current = true;
+    apiClient
+      .get<{ value: number; label: string }[]>("/ticket-priorities")
+      .then((d) => setPriorities(d.map((p) => ({ value: String(p.value), label: p.label }))))
+      .catch(() => {});
+  }, []);
 
-    fetchTickets();
-    fetchPriorities();
-  }, [fetchTickets, fetchPriorities]);
+  // The displayed option is the cached one only when its id matches the URL state.
+  // Direct-URL nav or reset will not match → render empty input (filter still applies).
+  const displayedAssignee =
+    state.assigneeId !== undefined && Number(assigneeOption?.id) === state.assigneeId
+      ? assigneeOption
+      : null;
+  const displayedEvent =
+    state.eventId !== undefined && Number(eventOption?.id) === state.eventId ? eventOption : null;
 
-  const setNewAssignee = (newAssignee: SearchSelectOption<UserResult> | null) => {
-    setAssignedToMe(false);
-    setAssignee(newAssignee);
-    fetchTickets(undefined, { assignee: newAssignee });
+  const tickets: Ticket[] = data?.items ?? [];
+  const totalCount = data?.numItems ?? 0;
+  const numPages = data?.numPages ?? 1;
+  const page = state.page;
+  const hasPrevious = page > 1;
+  const hasNext = page < numPages;
+
+  const allOpenShown = !openStatusValues.some((s) => state.excludeStatus.includes(s));
+  const assignedToMe = !!user && state.assigneeId === user.id;
+
+  const setNewAssignee = (next: SearchSelectOption<UserResult> | null) => {
+    setAssigneeOption(next);
+    setParam("assigneeId", next ? Number(next.id) : undefined);
   };
 
   const toggleAssignedToMe = () => {
     if (assignedToMe) {
-      setAssignedToMe(false);
-      setAssignee(null);
-      fetchTickets(undefined, { assignee: null });
+      setNewAssignee(null);
     } else if (user) {
       const meOption: SearchSelectOption<UserResult> = {
         id: user.id,
@@ -194,73 +133,45 @@ export default function TicketTemplateView({
           last_name: user.last_name,
         },
       };
-      setAssignedToMe(true);
-      setAssignee(meOption);
-      fetchTickets(undefined, { assignee: meOption });
+      setNewAssignee(meOption);
     }
+  };
+
+  const setNewEvent = (next: SearchSelectOption<EventResult> | null) => {
+    setEventOption(next);
+    setParam("eventId", next ? Number(next.id) : undefined);
   };
 
   const toggleStatus = (statusValue: string) => {
-    const newExcluded = excludedStatuses.includes(statusValue)
-      ? excludedStatuses.filter((s) => s !== statusValue)
-      : [...excludedStatuses, statusValue];
-    setExcludedStatuses(newExcluded);
-    fetchTickets(undefined, { excludedStatuses: newExcluded });
+    const newExcluded = state.excludeStatus.includes(statusValue)
+      ? state.excludeStatus.filter((s) => s !== statusValue)
+      : [...state.excludeStatus, statusValue];
+    setMany({ excludeStatus: newExcluded, page: 1 });
   };
 
   const toggleAllOpen = () => {
-    const allOpenShown = !openStatusValues.some((s) => excludedStatuses.includes(s));
-    const newExcluded = allOpenShown
-      ? [...new Set([...excludedStatuses, ...openStatusValues])]
-      : excludedStatuses.filter((s) => !openStatusValues.includes(s));
-    setExcludedStatuses(newExcluded);
-    fetchTickets(undefined, { excludedStatuses: newExcluded });
+    const allShown = !openStatusValues.some((s) => state.excludeStatus.includes(s));
+    const newExcluded = allShown
+      ? [...new Set([...state.excludeStatus, ...openStatusValues])]
+      : state.excludeStatus.filter((s) => !openStatusValues.includes(s));
+    setMany({ excludeStatus: newExcluded, page: 1 });
+  };
+
+  const onStatusToggle = () => {
+    const hasExcludedClosed = closedStatusValues.some((s) => state.excludeStatus.includes(s));
+    const hasExcludedOpen = openStatusValues.some((s) => state.excludeStatus.includes(s));
+    let newExcluded: string[];
+    if (!hasExcludedOpen && hasExcludedClosed) newExcluded = [...openStatusValues];
+    else if (hasExcludedOpen && !hasExcludedClosed) newExcluded = [];
+    else newExcluded = [...closedStatusValues];
+    setMany({ excludeStatus: newExcluded, page: 1 });
   };
 
   const handleReset = () => {
-    setPriority(null);
-    setTicketType(null);
-    setAssignedToMe(false);
-    setAssignee(null);
-    setEvent(null);
-    setSortField(null);
-    setSortDirection(null);
-    setExcludedStatuses(defaultExcluded);
-    fetchTickets(undefined, {
-      priority: null,
-      ticketType: null,
-      assignee: null,
-      event: null,
-      sortField: null,
-      sortDirection: null,
-      excludedStatuses: defaultExcluded,
-    });
+    setAssigneeOption(null);
+    setEventOption(null);
+    reset();
   };
-
-  const handleSort = (field: SortField, direction: SortDirection) => {
-    setSortField(field);
-    setSortDirection(direction);
-    fetchTickets(undefined, { sortField: field, sortDirection: direction });
-  };
-
-  const buildFilterParams = () => {
-    const params = new URLSearchParams();
-    if (fixedType) {
-      params.append("type", fixedType);
-    } else if (ticketType) {
-      params.append("type", ticketType);
-    }
-    if (assignee) params.append("assigned_to", String(assignee.id));
-    if (event) params.append("event", String(event.id));
-    if (priority) params.append("priority", priority);
-    if (sortField && sortDirection) {
-      params.append("ordering", sortDirection === "desc" ? `-${sortField}` : sortField);
-    }
-    if (excludedStatuses.length > 0) params.append("exclude_status", excludedStatuses.join(","));
-    return params.toString();
-  };
-
-  const allOpenShown = !openStatusValues.some((s) => excludedStatuses.includes(s));
 
   return (
     <Container size="xl" py="xl">
@@ -284,7 +195,7 @@ export default function TicketTemplateView({
                   {statusBadges.map((s) => (
                     <Badge
                       key={s.value}
-                      variant={excludedStatuses.includes(s.value) ? "outline" : "filled"}
+                      variant={state.excludeStatus.includes(s.value) ? "outline" : "filled"}
                       style={{ cursor: "pointer" }}
                       onClick={() => toggleStatus(s.value)}
                     >
@@ -294,7 +205,7 @@ export default function TicketTemplateView({
                   <Text c="dimmed">|</Text>
                   <Badge
                     color="gray"
-                    variant={excludedStatuses.includes("COMPLETED") ? "outline" : "filled"}
+                    variant={state.excludeStatus.includes("COMPLETED") ? "outline" : "filled"}
                     style={{ cursor: "pointer" }}
                     onClick={() => toggleStatus("COMPLETED")}
                   >
@@ -302,7 +213,7 @@ export default function TicketTemplateView({
                   </Badge>
                   <Badge
                     color="red"
-                    variant={excludedStatuses.includes("CANCELED") ? "outline" : "filled"}
+                    variant={state.excludeStatus.includes("CANCELED") ? "outline" : "filled"}
                     style={{ cursor: "pointer" }}
                     onClick={() => toggleStatus("CANCELED")}
                   >
@@ -313,25 +224,28 @@ export default function TicketTemplateView({
                 <Group gap="md">
                   <Select
                     label="Priority"
-                    value={priority}
-                    onChange={(value) => {
-                      setPriority(value);
-                      fetchTickets(undefined, { priority: value });
-                    }}
+                    value={state.priority !== undefined ? String(state.priority) : null}
+                    onChange={(value) =>
+                      setMany({
+                        priority: value !== null ? Number(value) : undefined,
+                        page: 1,
+                      })
+                    }
                     placeholder="All priorities"
                     clearable
                     data={priorities}
                     style={{ flex: 1 }}
                   />
-                  {/* Only show Type dropdown when there are multiple types to choose from */}
                   {!fixedType && (
                     <Select
                       label="Type"
-                      value={ticketType}
-                      onChange={(value) => {
-                        setTicketType(value);
-                        fetchTickets(undefined, { ticketType: value });
-                      }}
+                      value={state.ticketType ?? null}
+                      onChange={(value) =>
+                        setMany({
+                          ticketType: (value ?? undefined) as TicketListState["ticketType"],
+                          page: 1,
+                        })
+                      }
                       placeholder="All types"
                       clearable
                       data={ticketTypes}
@@ -342,7 +256,7 @@ export default function TicketTemplateView({
                     endpoint="/api/users/"
                     label="Assignee"
                     placeholder="Search users…"
-                    value={assignee}
+                    value={displayedAssignee}
                     onChange={setNewAssignee}
                     clearable
                     disabled={assignedToMe}
@@ -358,11 +272,8 @@ export default function TicketTemplateView({
                     endpoint="/events"
                     label="Event"
                     placeholder="Search events…"
-                    value={event}
-                    onChange={(newEvent) => {
-                      setEvent(newEvent);
-                      fetchTickets(undefined, { event: newEvent });
-                    }}
+                    value={displayedEvent}
+                    onChange={setNewEvent}
                     clearable
                     mapResult={(e) => ({ id: e.id, label: e.name, raw: e })}
                   />
@@ -386,46 +297,31 @@ export default function TicketTemplateView({
             <TicketTable
               tickets={tickets}
               loading={loading}
-              sortField={sortField}
-              sortDirection={sortDirection}
-              onSort={handleSort}
-              filterParams={buildFilterParams()}
-              onStatusToggle={() => {
-                const hasExcludedClosed = closedStatusValues.some((s) =>
-                  excludedStatuses.includes(s)
-                );
-                const hasExcludedOpen = openStatusValues.some((s) => excludedStatuses.includes(s));
-                let newExcluded: string[];
-                if (!hasExcludedOpen && hasExcludedClosed) {
-                  newExcluded = [...openStatusValues];
-                } else if (hasExcludedOpen && !hasExcludedClosed) {
-                  newExcluded = [];
-                } else {
-                  newExcluded = [...closedStatusValues];
-                }
-                setExcludedStatuses(newExcluded);
-                fetchTickets(undefined, { excludedStatuses: newExcluded });
-              }}
+              sort={state.sort}
+              onSortChange={(next: TicketSort | undefined) => setMany({ sort: next, page: 1 })}
+              filterParams={queryString}
+              onStatusToggle={onStatusToggle}
             />
 
             <Paper p="sm" withBorder>
               <Group justify="space-between">
                 <span>
                   {totalCount} {totalCount === 1 ? "ticket" : "tickets"} found
+                  {numPages > 1 ? ` · page ${page} of ${numPages}` : null}
                 </span>
                 <Group gap="xs">
                   <ActionIcon
                     variant="filled"
-                    disabled={!previousUrl}
-                    onClick={() => previousUrl && fetchTickets(previousUrl)}
+                    disabled={!hasPrevious}
+                    onClick={() => setParam("page", page - 1)}
                     aria-label="Previous page"
                   >
                     <IconChevronLeft size={18} />
                   </ActionIcon>
                   <ActionIcon
                     variant="filled"
-                    disabled={!nextUrl}
-                    onClick={() => nextUrl && fetchTickets(nextUrl)}
+                    disabled={!hasNext}
+                    onClick={() => setParam("page", page + 1)}
                     aria-label="Next page"
                   >
                     <IconChevronRight size={18} />

--- a/Application/app/components/tickets/TicketTemplateView.tsx
+++ b/Application/app/components/tickets/TicketTemplateView.tsx
@@ -81,8 +81,7 @@ export default function TicketTemplateView({
   const [priorities, setPriorities] = useState<{ value: string; label: string }[]>([]);
 
   // SearchSelect needs the option's label to display; URL only carries the ID.
-  // Cache the last-clicked option locally so refresh-by-URL can still drive the filter
-  // (the input shows empty until the user re-opens it — acceptable v1 trade-off).
+  // The hydration effects below resolve the label when state arrives from the URL.
   const [assigneeOption, setAssigneeOption] = useState<SearchSelectOption<UserResult> | null>(null);
   const [eventOption, setEventOption] = useState<SearchSelectOption<EventResult> | null>(null);
 
@@ -93,8 +92,50 @@ export default function TicketTemplateView({
       .catch(() => {});
   }, []);
 
+  // Hydrate the assignee SearchSelect's label from `state.assigneeId` (which the URL carries) so
+  // a shared / refreshed link shows the persisted user instead of an empty input. The
+  // option-in-deps + id-match early-exit keeps this from looping after the effect's own setState.
+  useEffect(() => {
+    const id = state.assigneeId;
+    if (id === undefined) return;
+    if (assigneeOption && Number(assigneeOption.id) === id) return;
+    let cancelled = false;
+    apiClient
+      .get<UserResult>(`/users/${id}/`)
+      .then((u) => {
+        if (cancelled) return;
+        setAssigneeOption({
+          id: u.id,
+          label: u.first_name ? `${u.first_name} ${u.last_name} (${u.username})` : u.username,
+          raw: u,
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [state.assigneeId, assigneeOption]);
+
+  // Same idea for the event SearchSelect — uses the standard DRF retrieve endpoint.
+  useEffect(() => {
+    const id = state.eventId;
+    if (id === undefined) return;
+    if (eventOption && Number(eventOption.id) === id) return;
+    let cancelled = false;
+    apiClient
+      .get<EventResult>(`/events/${id}/`)
+      .then((e) => {
+        if (cancelled) return;
+        setEventOption({ id: e.id, label: e.name, raw: e });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [state.eventId, eventOption]);
+
   // The displayed option is the cached one only when its id matches the URL state.
-  // Direct-URL nav or reset will not match → render empty input (filter still applies).
+  // Direct-URL nav lands on `null` for one render until the hydration effect resolves the label.
   const displayedAssignee =
     state.assigneeId !== undefined && Number(assigneeOption?.id) === state.assigneeId
       ? assigneeOption

--- a/Application/app/components/tickets/ticket-list.test.ts
+++ b/Application/app/components/tickets/ticket-list.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { deserializeQuery } from "@/app/lib/list";
+import {
+  buildTicketsListQuery,
+  ticketListQuerySchema,
+  DEFAULT_EXCLUDED_STATUSES,
+} from "./ticket-list";
+
+const parse = (qs: string) => deserializeQuery(new URLSearchParams(qs), ticketListQuerySchema);
+
+describe("buildTicketsListQuery", () => {
+  it("emits Django wire names with defaults", () => {
+    const params = buildTicketsListQuery(parse(""));
+    expect(params.get("page")).toBe("1");
+    expect(params.get("page_size")).toBe("20");
+    expect(params.get("exclude_status")).toBe("COMPLETED,CANCELED");
+    expect(params.has("ordering")).toBe(false);
+    expect(params.has("priority")).toBe(false);
+    expect(params.has("type")).toBe(false);
+  });
+
+  it("maps frontend names to backend names", () => {
+    const params = buildTicketsListQuery(
+      parse("priority=2&ticketType=RECRUIT&assigneeId=42&eventId=7&page=3&perPage=50")
+    );
+    expect(params.get("priority")).toBe("2");
+    expect(params.get("type")).toBe("RECRUIT");
+    expect(params.get("assigned_to")).toBe("42");
+    expect(params.get("event")).toBe("7");
+    expect(params.get("page")).toBe("3");
+    expect(params.get("page_size")).toBe("50");
+  });
+
+  it("appends id tiebreaker to ordering for stable pagination", () => {
+    const params = buildTicketsListQuery(parse("sort=-priority"));
+    expect(params.get("ordering")).toBe("-priority,id");
+  });
+
+  it("omits exclude_status when explicitly empty", () => {
+    const params = buildTicketsListQuery(parse("excludeStatus="));
+    // Empty string falls back to default — verify the default is in fact applied
+    expect(params.get("exclude_status")).toBe("COMPLETED,CANCELED");
+  });
+
+  it("respects user-overridden excludeStatus", () => {
+    const params = buildTicketsListQuery(parse("excludeStatus=COMPLETED"));
+    expect(params.get("exclude_status")).toBe("COMPLETED");
+  });
+
+  it("rejects unknown ticketType values", () => {
+    const state = parse("ticketType=NOT_A_TYPE");
+    expect(state.ticketType).toBeUndefined();
+    const params = buildTicketsListQuery(state);
+    expect(params.has("type")).toBe(false);
+  });
+
+  it("rejects unknown sort values", () => {
+    const state = parse("sort=banana");
+    expect(state.sort).toBeUndefined();
+    const params = buildTicketsListQuery(state);
+    expect(params.has("ordering")).toBe(false);
+  });
+});
+
+describe("ticketListQuerySchema defaults", () => {
+  it("excludes COMPLETED and CANCELED by default", () => {
+    expect(DEFAULT_EXCLUDED_STATUSES).toEqual(["COMPLETED", "CANCELED"]);
+    const state = parse("");
+    expect(state.excludeStatus).toEqual(["COMPLETED", "CANCELED"]);
+  });
+
+  it("page defaults to 1, perPage to 20", () => {
+    const state = parse("");
+    expect(state.page).toBe(1);
+    expect(state.perPage).toBe(20);
+  });
+});

--- a/Application/app/components/tickets/ticket-list.ts
+++ b/Application/app/components/tickets/ticket-list.ts
@@ -1,0 +1,109 @@
+import { apiClient } from "@/app/lib/apiClient";
+import {
+  deserializeQueryPaginationOptions,
+  toBackendPageParams,
+  type PaginatedServiceResponse,
+  type TypedFromSchema,
+} from "@/app/lib/list";
+import type { Ticket } from "./ticket-utils";
+
+export const TICKET_STATUS_VALUES = [
+  "OPEN",
+  "TODO",
+  "IN_PROGRESS",
+  "BLOCKED",
+  "COMPLETED",
+  "CANCELED",
+] as const;
+
+export const TICKET_TYPE_VALUES = [
+  "UNKNOWN",
+  "INTRODUCTION",
+  "RECRUIT",
+  "CONFIRM",
+  "INTERNAL",
+] as const;
+
+export const TICKET_SORT_VALUES = [
+  "priority",
+  "-priority",
+  "created_at",
+  "-created_at",
+  "title",
+  "-title",
+  "id",
+  "-id",
+  "assigned_to_id",
+  "-assigned_to_id",
+] as const;
+
+export type TicketSort = (typeof TICKET_SORT_VALUES)[number];
+
+export const DEFAULT_EXCLUDED_STATUSES: readonly string[] = ["COMPLETED", "CANCELED"];
+
+export const ticketListQuerySchema = {
+  ...deserializeQueryPaginationOptions,
+  priority: { type: "integer" as const, min: 0, max: 5 },
+  ticketType: { type: "enum" as const, values: TICKET_TYPE_VALUES },
+  assigneeId: { type: "integer" as const, min: 1 },
+  eventId: { type: "integer" as const, min: 1 },
+  excludeStatus: {
+    type: "stringArray" as const,
+    defaultValue: [...DEFAULT_EXCLUDED_STATUSES],
+  },
+  sort: { type: "enum" as const, values: TICKET_SORT_VALUES },
+};
+
+export type TicketListState = TypedFromSchema<typeof ticketListQuerySchema>;
+
+/**
+ * Translate typed list state into the URLSearchParams Django expects.
+ * Spirit of getXTableWhere: omit undefined fields, no "any" markers, plus a stable
+ * tiebreaker (id ASC) appended to sort so paginated results don't reshuffle across pages.
+ */
+export function buildTicketsListQuery(state: TicketListState): URLSearchParams {
+  const params = new URLSearchParams();
+
+  for (const [k, v] of Object.entries(
+    toBackendPageParams({ page: state.page, perPage: state.perPage })
+  )) {
+    params.set(k, v);
+  }
+
+  if (state.priority !== undefined) params.set("priority", String(state.priority));
+  if (state.ticketType !== undefined) params.set("type", state.ticketType);
+  if (state.assigneeId !== undefined) params.set("assigned_to", String(state.assigneeId));
+  if (state.eventId !== undefined) params.set("event", String(state.eventId));
+  if (state.excludeStatus.length > 0) params.set("exclude_status", state.excludeStatus.join(","));
+  if (state.sort !== undefined) params.set("ordering", `${state.sort},id`);
+
+  return params;
+}
+
+/**
+ * Presenter — runs each row through a normalization step before it leaves the data layer.
+ * Today this is near-identity; the seam exists so display fields can be centralized later
+ * without leaking raw DB shapes to the UI.
+ */
+export function presentTicket(row: Ticket): Ticket {
+  return row;
+}
+
+interface DrfPaginated<T> {
+  results: T[];
+  count: number;
+  next: string | null;
+  previous: string | null;
+}
+
+/**
+ * Service-method analog: returns only { items, numItems }. The API/render layer enriches
+ * with page, perPage, numPages via makePaginatedResponse.
+ */
+export async function fetchTicketsList(
+  state: TicketListState
+): Promise<PaginatedServiceResponse<Ticket>> {
+  const qs = buildTicketsListQuery(state).toString();
+  const data = await apiClient.get<DrfPaginated<Ticket>>(`/tickets?${qs}`);
+  return { items: data.results ?? [], numItems: data.count ?? 0 };
+}

--- a/Application/app/lib/list/deserializeQuery.test.ts
+++ b/Application/app/lib/list/deserializeQuery.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  deserializeQuery,
+  deserializeQueryPaginationOptions,
+  serializeQuery,
+} from "./deserializeQuery";
+
+const sp = (s: string) => new URLSearchParams(s);
+
+describe("deserializeQuery", () => {
+  it("parses string fields", () => {
+    const out = deserializeQuery(sp("name=alice"), {
+      name: { type: "string" },
+    });
+    expect(out.name).toBe("alice");
+  });
+
+  it("returns defaultValue when missing", () => {
+    const out = deserializeQuery(sp(""), {
+      name: { type: "string", defaultValue: "anon" },
+    });
+    expect(out.name).toBe("anon");
+  });
+
+  it("parses integers and clamps to min/max", () => {
+    const out = deserializeQuery(sp("page=0&perPage=999"), {
+      ...deserializeQueryPaginationOptions,
+    });
+    expect(out.page).toBe(1); // clamped to min 1
+    expect(out.perPage).toBe(999); // no max set
+  });
+
+  it("falls back to defaultValue on malformed integer", () => {
+    const out = deserializeQuery(sp("page=banana"), {
+      ...deserializeQueryPaginationOptions,
+    });
+    expect(out.page).toBe(1);
+  });
+
+  it("parses stringArray (comma-separated, trimmed)", () => {
+    const out = deserializeQuery(sp("excludeStatus=COMPLETED, CANCELED"), {
+      excludeStatus: { type: "stringArray", defaultValue: [] },
+    });
+    expect(out.excludeStatus).toEqual(["COMPLETED", "CANCELED"]);
+  });
+
+  it("parses booleans", () => {
+    const a = deserializeQuery(sp("active=true"), { active: { type: "boolean" } });
+    const b = deserializeQuery(sp("active=false"), { active: { type: "boolean" } });
+    const c = deserializeQuery(sp("active=banana"), {
+      active: { type: "boolean", defaultValue: false },
+    });
+    expect(a.active).toBe(true);
+    expect(b.active).toBe(false);
+    expect(c.active).toBe(false);
+  });
+
+  it("parses dates and falls back when malformed", () => {
+    const fallback = new Date("2026-01-01T00:00:00Z");
+    const a = deserializeQuery(sp("when=2026-05-05T00:00:00Z"), {
+      when: { type: "date" },
+    });
+    const b = deserializeQuery(sp("when=not-a-date"), {
+      when: { type: "date", defaultValue: fallback },
+    });
+    expect(a.when?.toISOString()).toBe("2026-05-05T00:00:00.000Z");
+    expect(b.when).toBe(fallback);
+  });
+
+  it("parses enums and rejects unknown values", () => {
+    const a = deserializeQuery(sp("color=red"), {
+      color: { type: "enum", values: ["red", "green", "blue"] as const },
+    });
+    const b = deserializeQuery(sp("color=mauve"), {
+      color: { type: "enum", values: ["red", "green", "blue"] as const, defaultValue: "red" },
+    });
+    expect(a.color).toBe("red");
+    expect(b.color).toBe("red");
+  });
+
+  it("silently drops unknown URL keys", () => {
+    const out = deserializeQuery(sp("page=2&unknownKey=42"), {
+      ...deserializeQueryPaginationOptions,
+    });
+    expect(out).toEqual({ page: 2, perPage: 20 });
+    expect("unknownKey" in out).toBe(false);
+  });
+});
+
+describe("serializeQuery", () => {
+  it("omits fields equal to defaultValue", () => {
+    const params = serializeQuery(
+      { ...deserializeQueryPaginationOptions },
+      { page: 1, perPage: 20 }
+    );
+    expect(params.toString()).toBe("");
+  });
+
+  it("emits fields differing from defaults", () => {
+    const params = serializeQuery(
+      { ...deserializeQueryPaginationOptions },
+      { page: 3, perPage: 20 }
+    );
+    expect(params.get("page")).toBe("3");
+    expect(params.has("perPage")).toBe(false);
+  });
+
+  it("round-trips stringArray values", () => {
+    const schema = {
+      excludeStatus: { type: "stringArray" as const, defaultValue: ["A", "B"] },
+    };
+    const params = serializeQuery(schema, { excludeStatus: ["A", "C"] });
+    expect(params.get("excludeStatus")).toBe("A,C");
+
+    // Equal-to-default should be omitted
+    const p2 = serializeQuery(schema, { excludeStatus: ["A", "B"] });
+    expect(p2.has("excludeStatus")).toBe(false);
+  });
+});

--- a/Application/app/lib/list/deserializeQuery.ts
+++ b/Application/app/lib/list/deserializeQuery.ts
@@ -1,0 +1,152 @@
+import { DEFAULT_PAGE, DEFAULT_PER_PAGE } from "./pagination";
+
+export type QueryFieldDef =
+  | { type: "string"; defaultValue?: string }
+  | { type: "stringArray"; defaultValue?: string[] }
+  | { type: "boolean"; defaultValue?: boolean }
+  | { type: "date"; defaultValue?: Date }
+  | { type: "integer"; defaultValue?: number; min?: number; max?: number }
+  | { type: "float"; defaultValue?: number; min?: number; max?: number }
+  | { type: "enum"; values: readonly string[]; defaultValue?: string };
+
+export type QuerySchema = Record<string, QueryFieldDef>;
+
+type FieldValue<F extends QueryFieldDef> = F extends { type: "string" }
+  ? F extends { defaultValue: string }
+    ? string
+    : string | undefined
+  : F extends { type: "stringArray" }
+    ? F extends { defaultValue: string[] }
+      ? string[]
+      : string[] | undefined
+    : F extends { type: "boolean" }
+      ? F extends { defaultValue: boolean }
+        ? boolean
+        : boolean | undefined
+      : F extends { type: "date" }
+        ? F extends { defaultValue: Date }
+          ? Date
+          : Date | undefined
+        : F extends { type: "integer" | "float" }
+          ? F extends { defaultValue: number }
+            ? number
+            : number | undefined
+          : F extends { type: "enum"; values: readonly (infer T)[] }
+            ? F extends { defaultValue: string }
+              ? T
+              : T | undefined
+            : never;
+
+export type TypedFromSchema<S extends QuerySchema> = { [K in keyof S]: FieldValue<S[K]> };
+
+export interface SearchParamsLike {
+  get(name: string): string | null;
+  getAll?(name: string): string[];
+  forEach?(cb: (value: string, key: string) => void): void;
+}
+
+function clamp(n: number, min?: number, max?: number): number {
+  if (min !== undefined && n < min) n = min;
+  if (max !== undefined && n > max) n = max;
+  return n;
+}
+
+function parseField(raw: string | null, field: QueryFieldDef): unknown {
+  if (raw === null || raw === "") {
+    // Copy arrays so consumers can mutate the result without affecting the schema's default.
+    if (field.type === "stringArray" && Array.isArray(field.defaultValue)) {
+      return [...field.defaultValue];
+    }
+    return field.defaultValue;
+  }
+  switch (field.type) {
+    case "string":
+      return raw;
+    case "stringArray": {
+      const parts = raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (parts.length > 0) return parts;
+      return Array.isArray(field.defaultValue) ? [...field.defaultValue] : field.defaultValue;
+    }
+    case "boolean":
+      if (raw === "true") return true;
+      if (raw === "false") return false;
+      return field.defaultValue;
+    case "date": {
+      const d = new Date(raw);
+      return Number.isNaN(d.getTime()) ? field.defaultValue : d;
+    }
+    case "integer": {
+      const n = Number.parseInt(raw, 10);
+      if (!Number.isFinite(n)) return field.defaultValue;
+      return clamp(n, field.min, field.max);
+    }
+    case "float": {
+      const n = Number.parseFloat(raw);
+      if (!Number.isFinite(n)) return field.defaultValue;
+      return clamp(n, field.min, field.max);
+    }
+    case "enum":
+      return field.values.includes(raw) ? raw : field.defaultValue;
+  }
+}
+
+export function deserializeQuery<S extends QuerySchema>(
+  searchParams: SearchParamsLike,
+  schema: S
+): TypedFromSchema<S> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(schema)) {
+    out[key] = parseField(searchParams.get(key), schema[key]);
+  }
+  return out as TypedFromSchema<S>;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => v === b[i]);
+  }
+  return false;
+}
+
+function serializeField(value: unknown, field: QueryFieldDef): string | null {
+  if (value === undefined) return null;
+  if (valuesEqual(value, field.defaultValue)) return null;
+  switch (field.type) {
+    case "string":
+      return String(value);
+    case "stringArray":
+      return Array.isArray(value) ? (value as string[]).join(",") : null;
+    case "boolean":
+      return value ? "true" : "false";
+    case "date":
+      return value instanceof Date ? value.toISOString() : null;
+    case "integer":
+    case "float":
+      return String(value);
+    case "enum":
+      return String(value);
+  }
+}
+
+export function serializeQuery<S extends QuerySchema>(
+  schema: S,
+  state: Partial<TypedFromSchema<S>>
+): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const key of Object.keys(schema)) {
+    const v = serializeField(state[key as keyof typeof state], schema[key]);
+    if (v !== null) params.set(key, v);
+  }
+  return params;
+}
+
+export const deserializeQueryPaginationOptions = {
+  page: { type: "integer" as const, defaultValue: DEFAULT_PAGE, min: 1 },
+  perPage: { type: "integer" as const, defaultValue: DEFAULT_PER_PAGE, min: 0 },
+};

--- a/Application/app/lib/list/index.ts
+++ b/Application/app/lib/list/index.ts
@@ -1,0 +1,30 @@
+export {
+  DEFAULT_PAGE,
+  DEFAULT_PER_PAGE,
+  handlePagination,
+  toBackendPageParams,
+  makePaginatedResponse,
+  type PaginationParams,
+  type PaginatedServiceResponse,
+  type PaginatedResponse,
+} from "./pagination";
+
+export {
+  deserializeQuery,
+  serializeQuery,
+  deserializeQueryPaginationOptions,
+  type QueryFieldDef,
+  type QuerySchema,
+  type TypedFromSchema,
+  type SearchParamsLike,
+} from "./deserializeQuery";
+
+export { useListQuery, type UseListQueryOptions, type UseListQueryResult } from "./useListQuery";
+
+export {
+  defineListResource,
+  buildListQuery,
+  type ResourceConfig,
+  type ListResource,
+  type WireMap,
+} from "./resource";

--- a/Application/app/lib/list/pagination.test.ts
+++ b/Application/app/lib/list/pagination.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { handlePagination, makePaginatedResponse, toBackendPageParams } from "./pagination";
+
+describe("handlePagination", () => {
+  it("computes skip/take for page 1", () => {
+    expect(handlePagination({ page: 1, perPage: 20 })).toEqual({ skip: 0, take: 20 });
+  });
+
+  it("computes skip/take for page 3", () => {
+    expect(handlePagination({ page: 3, perPage: 20 })).toEqual({ skip: 40, take: 20 });
+  });
+
+  it("returns take=0 when perPage is 0", () => {
+    expect(handlePagination({ page: 1, perPage: 0 })).toEqual({ skip: 0, take: 0 });
+  });
+});
+
+describe("toBackendPageParams", () => {
+  it("maps to Django page/page_size names", () => {
+    expect(toBackendPageParams({ page: 2, perPage: 50 })).toEqual({
+      page: "2",
+      page_size: "50",
+    });
+  });
+});
+
+describe("makePaginatedResponse", () => {
+  const id = <T>(x: T) => x;
+
+  it("computes numPages by ceil(numItems/perPage)", () => {
+    const res = makePaginatedResponse(
+      { items: [1, 2, 3], numItems: 47 },
+      { page: 1, perPage: 20, present: id }
+    );
+    expect(res.numPages).toBe(3);
+    expect(res.numItems).toBe(47);
+    expect(res.page).toBe(1);
+    expect(res.perPage).toBe(20);
+  });
+
+  it("returns numPages=0 when perPage is 0 (no rows)", () => {
+    const res = makePaginatedResponse(
+      { items: [], numItems: 0 },
+      { page: 1, perPage: 0, present: id }
+    );
+    expect(res.numPages).toBe(0);
+  });
+
+  it("returns numPages=1 when zero items but non-zero perPage", () => {
+    const res = makePaginatedResponse(
+      { items: [], numItems: 0 },
+      { page: 1, perPage: 20, present: id }
+    );
+    expect(res.numPages).toBe(1);
+  });
+
+  it("runs each row through the presenter", () => {
+    const res = makePaginatedResponse(
+      { items: [1, 2, 3], numItems: 3 },
+      { page: 1, perPage: 20, present: (n: number) => n * 10 }
+    );
+    expect(res.items).toEqual([10, 20, 30]);
+  });
+});

--- a/Application/app/lib/list/pagination.ts
+++ b/Application/app/lib/list/pagination.ts
@@ -1,0 +1,46 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PER_PAGE = 20;
+
+export interface PaginationParams {
+  page: number;
+  perPage: number;
+}
+
+export interface PaginatedServiceResponse<T> {
+  items: T[];
+  numItems: number;
+}
+
+export interface PaginatedResponse<T> extends PaginatedServiceResponse<T> {
+  page: number;
+  perPage: number;
+  numPages: number;
+}
+
+export function handlePagination({ page, perPage }: PaginationParams): {
+  skip: number;
+  take: number;
+} {
+  return { skip: (page - 1) * perPage, take: perPage };
+}
+
+export function toBackendPageParams({ page, perPage }: PaginationParams): Record<string, string> {
+  return { page: String(page), page_size: String(perPage) };
+}
+
+export function makePaginatedResponse<TRow, TOut>(
+  service: PaginatedServiceResponse<TRow>,
+  opts: { page: number; perPage: number; present: (row: TRow) => TOut }
+): PaginatedResponse<TOut> {
+  const { page, perPage, present } = opts;
+  // perPage 0 is the explicit "no rows" signal — there are no pages to show.
+  // Otherwise round up; clamp to 1 so an empty list still renders page 1.
+  const numPages = perPage === 0 ? 0 : Math.max(1, Math.ceil(service.numItems / perPage));
+  return {
+    items: service.items.map(present),
+    numItems: service.numItems,
+    page,
+    perPage,
+    numPages,
+  };
+}

--- a/Application/app/lib/list/resource.test.ts
+++ b/Application/app/lib/list/resource.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { buildListQuery } from "./resource";
+import { deserializeQueryPaginationOptions, type TypedFromSchema } from "./deserializeQuery";
+import type { WireMap } from "./resource";
+
+const baseSchema = {
+  ...deserializeQueryPaginationOptions,
+  q: { type: "string" as const },
+  count: { type: "integer" as const, min: 0 },
+  active: { type: "boolean" as const },
+  tags: { type: "stringArray" as const, defaultValue: [] as string[] },
+};
+
+type BaseState = TypedFromSchema<typeof baseSchema>;
+
+const state = (overrides: Partial<BaseState> = {}): BaseState => ({
+  page: 1,
+  perPage: 20,
+  q: undefined,
+  count: undefined,
+  active: undefined,
+  tags: [],
+  ...overrides,
+});
+
+describe("buildListQuery", () => {
+  it("emits DRF page/page_size by default", () => {
+    const p = buildListQuery(state({ page: 3, perPage: 50 }), { schema: baseSchema });
+    expect(p.get("page")).toBe("3");
+    expect(p.get("page_size")).toBe("50");
+  });
+
+  it("omits fields whose value is undefined", () => {
+    const p = buildListQuery(state(), { schema: baseSchema });
+    expect(p.has("q")).toBe(false);
+    expect(p.has("count")).toBe(false);
+    expect(p.has("active")).toBe(false);
+  });
+
+  it("emits unmapped fields under their schema name when defined", () => {
+    const p = buildListQuery(state({ q: "hello", count: 7, active: true }), { schema: baseSchema });
+    expect(p.get("q")).toBe("hello");
+    expect(p.get("count")).toBe("7");
+    expect(p.get("active")).toBe("true");
+  });
+
+  it("renames a field via a string wire rule", () => {
+    const p = buildListQuery(state({ count: 9 }), {
+      schema: baseSchema,
+      wire: { count: "total" },
+    });
+    expect(p.has("count")).toBe(false);
+    expect(p.get("total")).toBe("9");
+  });
+
+  it("string wire rule still omits when value is undefined", () => {
+    const p = buildListQuery(state(), {
+      schema: baseSchema,
+      wire: { count: "total" },
+    });
+    expect(p.has("total")).toBe(false);
+  });
+
+  it("function wire rule receives params, the field value, and full state", () => {
+    let seenValue: unknown;
+    let seenState: unknown;
+    buildListQuery(state({ q: "abc", count: 5 }), {
+      schema: baseSchema,
+      wire: {
+        q: (params, value, s) => {
+          seenValue = value;
+          seenState = s;
+          if (value !== undefined) params.set("search", `*${value}*`);
+        },
+      },
+    });
+    expect(seenValue).toBe("abc");
+    expect(seenState).toMatchObject({ q: "abc", count: 5 });
+  });
+
+  it("function wire rule can transform array fields into comma-joined values", () => {
+    const p = buildListQuery(state({ tags: ["red", "blue"] }), {
+      schema: baseSchema,
+      wire: {
+        tags: (params, value) => {
+          if (value.length > 0) params.set("tags", value.join(","));
+        },
+      },
+    });
+    expect(p.get("tags")).toBe("red,blue");
+  });
+
+  it("function wire rule can skip emission for default values", () => {
+    const p = buildListQuery(state({ tags: [] }), {
+      schema: baseSchema,
+      wire: {
+        tags: (params, value) => {
+          if (value.length > 0) params.set("tags", value.join(","));
+        },
+      },
+    });
+    expect(p.has("tags")).toBe(false);
+  });
+
+  it("function wire rule can derive a wire value (e.g. sort tiebreaker)", () => {
+    const sortSchema = {
+      ...deserializeQueryPaginationOptions,
+      sort: { type: "enum" as const, values: ["name", "-name"] as const },
+    };
+    const p = buildListQuery(
+      { page: 1, perPage: 20, sort: "-name" as const },
+      {
+        schema: sortSchema,
+        wire: {
+          sort: (params, value) => {
+            if (value !== undefined) params.set("ordering", `${value},id`);
+          },
+        },
+      }
+    );
+    expect(p.get("ordering")).toBe("-name,id");
+    expect(p.has("sort")).toBe(false);
+  });
+
+  it("honors a custom pageParams encoder (limit/offset style)", () => {
+    const p = buildListQuery(state({ page: 3, perPage: 25 }), {
+      schema: baseSchema,
+      pageParams: ({ page, perPage }) => ({
+        limit: String(perPage),
+        offset: String((page - 1) * perPage),
+      }),
+    });
+    expect(p.get("limit")).toBe("25");
+    expect(p.get("offset")).toBe("50");
+    expect(p.has("page")).toBe(false);
+    expect(p.has("page_size")).toBe(false);
+  });
+
+  it("does not emit page/perPage through the wire loop even with a rule for them", () => {
+    const p = buildListQuery(state({ page: 2 }), {
+      schema: baseSchema,
+      // A rule on page/perPage is ignored — pagination is owned by pageParams.
+      wire: { page: "p" } as WireMap<typeof baseSchema>,
+    });
+    expect(p.has("p")).toBe(false);
+    expect(p.get("page")).toBe("2");
+  });
+});

--- a/Application/app/lib/list/resource.ts
+++ b/Application/app/lib/list/resource.ts
@@ -1,0 +1,125 @@
+import { apiClient } from "@/app/lib/apiClient";
+import {
+  toBackendPageParams,
+  makePaginatedResponse,
+  type PaginationParams,
+  type PaginatedResponse,
+} from "./pagination";
+import type { QuerySchema, TypedFromSchema } from "./deserializeQuery";
+
+/**
+ * Per-field rule for translating typed list state into the wire URLSearchParams a backend expects.
+ *
+ * - string: rename — emit value under this wire key when defined.
+ * - function: full control — callee decides whether and how to write to `params`. Use for
+ *   array fields, composite values, or wire keys that need a derived suffix (e.g. a sort
+ *   tiebreaker).
+ *
+ * Schema keys with no rule are emitted under their schema name when defined.
+ */
+type WireRule<S extends QuerySchema, K extends keyof S> =
+  | string
+  | ((params: URLSearchParams, value: TypedFromSchema<S>[K], state: TypedFromSchema<S>) => void);
+
+export type WireMap<S extends QuerySchema> = { [K in keyof S]?: WireRule<S, K> };
+
+interface DrfPaginated<T> {
+  results: T[];
+  count: number;
+}
+
+export interface ResourceConfig<S extends QuerySchema, TRow, TOut = TRow> {
+  /** Backend path, e.g. "/tickets". */
+  endpoint: string;
+  /** URL state schema. Pass the same value used by `useListQuery`. */
+  schema: S;
+  /** Per-field wire rules. Unmapped fields are sent under their schema name when defined. */
+  wire?: WireMap<S>;
+  /** Per-row transform applied between the data layer and the UI. Defaults to identity. */
+  present?: (row: TRow) => TOut;
+  /** Encode pagination. Defaults to DRF's `{page, page_size}`. */
+  pageParams?: (p: PaginationParams) => Record<string, string>;
+}
+
+export interface ListResource<S extends QuerySchema, TOut> {
+  schema: S;
+  fetcher: (state: TypedFromSchema<S>) => Promise<PaginatedResponse<TOut>>;
+}
+
+type PaginationFields = {
+  page: { type: "integer"; defaultValue: number; min?: number; max?: number };
+  perPage: { type: "integer"; defaultValue: number; min?: number; max?: number };
+};
+
+/**
+ * Translate typed list state into the wire `URLSearchParams` per `cfg.schema` + `cfg.wire`.
+ * Pure — no I/O. Exported so consumers can build URLs for non-fetch contexts (download links,
+ * deep-link buttons) and so tests can exercise the mapping logic directly.
+ */
+export function buildListQuery<S extends QuerySchema & PaginationFields>(
+  state: TypedFromSchema<S>,
+  cfg: {
+    schema: S;
+    wire?: WireMap<S>;
+    pageParams?: (p: PaginationParams) => Record<string, string>;
+  }
+): URLSearchParams {
+  const pageParams = cfg.pageParams ?? toBackendPageParams;
+  const wireMap = (cfg.wire ?? {}) as Record<string, WireRule<S, keyof S> | undefined>;
+  const params = new URLSearchParams();
+
+  for (const [k, v] of Object.entries(pageParams({ page: state.page, perPage: state.perPage }))) {
+    params.set(k, v);
+  }
+
+  for (const key of Object.keys(cfg.schema)) {
+    if (key === "page" || key === "perPage") continue;
+    const value = (state as Record<string, unknown>)[key];
+    const rule = wireMap[key];
+    if (typeof rule === "function") {
+      (rule as (p: URLSearchParams, v: unknown, s: TypedFromSchema<S>) => void)(
+        params,
+        value,
+        state
+      );
+    } else if (value !== undefined) {
+      params.set(rule ?? key, String(value));
+    }
+  }
+
+  return params;
+}
+
+/**
+ * Build a `{schema, fetcher}` pair ready for `useListQuery` from a declarative description of a
+ * paginated list endpoint. Replaces the hand-written `buildXListQuery + fetchXList` pair for the
+ * common case of "DRF endpoint + simple UI→wire renaming + occasional custom serialization".
+ *
+ * The function form of a wire rule is the escape hatch for cases the rename-only path can't
+ * express: comma-joined arrays, conditional emission, derived suffixes, etc.
+ *
+ * Type constraint on `S`: schemas must include `page` and `perPage` integer fields with defaults
+ * (i.e. spread `deserializeQueryPaginationOptions`). Non-paginated lists aren't supported here —
+ * use `useListQuery` directly with a custom fetcher.
+ */
+export function defineListResource<S extends QuerySchema & PaginationFields, TRow, TOut = TRow>(
+  cfg: ResourceConfig<S, TRow, TOut>
+): ListResource<S, TOut> {
+  const present = cfg.present ?? ((row: TRow) => row as unknown as TOut);
+
+  return {
+    schema: cfg.schema,
+    fetcher: async (state) => {
+      const params = buildListQuery(state, cfg);
+      const qs = params.toString();
+      const url = qs ? `${cfg.endpoint}?${qs}` : cfg.endpoint;
+      const data = await apiClient.get<DrfPaginated<TRow>>(url);
+      const service = { items: data.results ?? [], numItems: data.count ?? 0 };
+      return makePaginatedResponse(service, {
+        page: state.page,
+        perPage: state.perPage,
+        present,
+      });
+    },
+  };
+}

--- a/Application/app/lib/list/useListQuery.ts
+++ b/Application/app/lib/list/useListQuery.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  deserializeQuery,
+  serializeQuery,
+  type QuerySchema,
+  type TypedFromSchema,
+} from "./deserializeQuery";
+import type { PaginatedResponse } from "./pagination";
+
+export interface UseListQueryResult<S extends QuerySchema, TOut> {
+  state: TypedFromSchema<S>;
+  setParam: <K extends keyof S>(key: K, value: TypedFromSchema<S>[K] | undefined) => void;
+  setMany: (partial: Partial<TypedFromSchema<S>>) => void;
+  reset: () => void;
+  data: PaginatedResponse<TOut> | undefined;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+  /** The serialized query string currently in the URL (without leading "?"). Useful for deep links. */
+  queryString: string;
+}
+
+export interface UseListQueryOptions<S extends QuerySchema, TOut> {
+  schema: S;
+  fetcher: (state: TypedFromSchema<S>) => Promise<PaginatedResponse<TOut>>;
+}
+
+/**
+ * Reads list state (filters/sort/pagination) from URL search params, drives a fetcher off it,
+ * and writes back to the URL when the consumer calls setParam/setMany/reset.
+ *
+ * Why route updates use replace(): each filter change shouldn't pollute browser history.
+ * Back-navigation from a detail page still restores filters because the URL at click-time
+ * is captured in history naturally.
+ */
+export function useListQuery<S extends QuerySchema, TOut>({
+  schema,
+  fetcher,
+}: UseListQueryOptions<S, TOut>): UseListQueryResult<S, TOut> {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const queryString = searchParams.toString();
+  // React Compiler memoizes this. Re-running deserializeQuery on each render is cheap
+  // (a small handful of string parses) and keeps the linter happy about manual memos.
+  const state = deserializeQuery(searchParams, schema);
+
+  const writeState = useCallback(
+    (next: Partial<TypedFromSchema<S>>) => {
+      const merged = { ...state, ...next } as TypedFromSchema<S>;
+      const serialized = serializeQuery(schema, merged).toString();
+      const nextUrl = serialized ? `${pathname}?${serialized}` : pathname;
+      router.replace(nextUrl, { scroll: false });
+    },
+    [state, pathname, router, schema]
+  );
+
+  const setParam = useCallback(
+    <K extends keyof S>(key: K, value: TypedFromSchema<S>[K] | undefined) => {
+      writeState({ [key]: value } as Partial<TypedFromSchema<S>>);
+    },
+    [writeState]
+  );
+
+  const setMany = useCallback(
+    (partial: Partial<TypedFromSchema<S>>) => {
+      writeState(partial);
+    },
+    [writeState]
+  );
+
+  const reset = useCallback(() => {
+    router.replace(pathname, { scroll: false });
+  }, [pathname, router]);
+
+  const [data, setData] = useState<PaginatedResponse<TOut>>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const refetch = useCallback(() => setRefreshToken((n) => n + 1), []);
+
+  // Re-run only when the URL string actually changes — `state` is a new object every render.
+  const fetcherRef = useRef(fetcher);
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetcherRef.current(state);
+        if (!cancelled) setData(res);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [queryString, refreshToken]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    state,
+    setParam,
+    setMany,
+    reset,
+    data,
+    loading,
+    error,
+    refetch,
+    queryString,
+  };
+}


### PR DESCRIPTION
Issue #270 asked that the /tickets queue's filter, sort, and pagination state live in the URL so views are shareable and browser back from a ticket detail restores the queue. Previously TicketTemplateView held everything in useState; nothing was reflected in the URL.

This change introduces a reusable URL-state + paginated-response pattern under Application/app/lib/list/ and converts the tickets list end-to-end as the canonical example. Other list pages (contacts, events, participants) can adopt the same helpers in follow-up work without further infrastructure.

The Django backend is unchanged. The client maps user-facing names (page, perPage, excludeStatus, sort) to Django wire names (page, page_size, exclude_status, ordering) per-resource, and translates DRF's {results, count} envelope into {items, numItems, numPages, page, perPage} on the way out.

Includes 29 new unit tests covering the deserializer, pagination math, and the tickets query builder.